### PR TITLE
Support Yang metadata extension (RFC 7952)

### DIFF
--- a/yang-modules/ietf/ietf-yang-metadata@2016-08-05.yang
+++ b/yang-modules/ietf/ietf-yang-metadata@2016-08-05.yang
@@ -1,0 +1,80 @@
+module ietf-yang-metadata {
+  namespace "urn:ietf:params:xml:ns:yang:ietf-yang-metadata";
+  prefix md;
+
+  organization
+    "IETF NETMOD (NETCONF Data Modeling Language) Working Group";
+  contact
+    "WG Web:   <https://datatracker.ietf.org/wg/netmod/>
+
+     WG List:  <mailto:netmod@ietf.org>
+
+     WG Chair: Lou Berger
+               <mailto:lberger@labn.net>
+
+     WG Chair: Kent Watsen
+               <mailto:kwatsen@juniper.net>
+
+     Editor:   Ladislav Lhotka
+               <mailto:lhotka@nic.cz>";
+  description
+    "This YANG module defines an 'extension' statement that allows
+     for defining metadata annotations.
+
+     Copyright (c) 2016 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject to
+     the license terms contained in, the Simplified BSD License set
+     forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (http://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC 7952
+     (http://www.rfc-editor.org/info/rfc7952); see the RFC itself
+     for full legal notices.";
+
+  revision 2016-08-05 {
+    description
+      "Initial revision.";
+    reference
+      "RFC 7952: Defining and Using Metadata with YANG";
+  }
+
+  extension annotation {
+    argument name;
+    description
+      "This extension allows for defining metadata annotations in
+       YANG modules.  The 'md:annotation' statement can appear only
+       at the top level of a YANG module or submodule, i.e., it
+       becomes a new alternative in the ABNF production rule for
+       'body-stmts' (Section 14 in RFC 7950).
+
+       The argument of the 'md:annotation' statement defines the name
+       of the annotation.  Syntactically, it is a YANG identifier as
+       defined in Section 6.2 of RFC 7950.
+
+       An annotation defined with this 'extension' statement inherits
+       the namespace and other context from the YANG module in which
+       it is defined.
+
+       The data type of the annotation value is specified in the same
+       way as for a leaf data node using the 'type' statement.
+
+       The semantics of the annotation and other documentation can be
+       specified using the following standard YANG substatements (all
+       are optional): 'description', 'if-feature', 'reference',
+       'status', and 'units'.
+
+       A server announces support for a particular annotation by
+       including the module in which the annotation is defined among
+       the advertised YANG modules, e.g., in a NETCONF <hello>
+       message or in the YANG library (RFC 7950).  The annotation can
+       then be attached to any instance of a data node defined in any
+       YANG module that is advertised by the server.
+
+       XML encoding and JSON encoding of annotations are defined in
+       RFC 7952.";
+  }
+}

--- a/yang-modules/test_metadata/meta@2016-04-26.yang
+++ b/yang-modules/test_metadata/meta@2016-04-26.yang
@@ -1,0 +1,25 @@
+module meta {
+
+  yang-version "1.1";
+
+  namespace "http://example.com/meta";
+
+  prefix "m";
+
+  import ietf-yang-types {
+    prefix "yang";
+    revision-date 2013-07-15;
+  }
+  import ietf-yang-metadata {
+    prefix "md";
+  }
+
+  revision 2016-04-26;
+
+  md:annotation last-modified {
+    type yang:date-and-time;
+    description
+      "This annotation contains the date and time when the
+       annotated instance was last modified (or created).";
+  }
+}

--- a/yang-modules/test_metadata/other@2016-04-26.yang
+++ b/yang-modules/test_metadata/other@2016-04-26.yang
@@ -1,0 +1,24 @@
+module meta {
+
+  yang-version "1.1";
+
+  namespace "http://example.com/meta";
+
+  prefix "m";
+
+  import ietf-yang-types {
+    prefix "yang";
+    revision-date 2013-07-15;
+  }
+
+  revision 2016-04-26;
+
+  container contA {
+    leaf leafA {
+      type int32;
+    }
+    leaf leafB {
+      type string;
+    }
+  }
+}

--- a/yang-modules/test_metadata/other@2016-04-26.yang
+++ b/yang-modules/test_metadata/other@2016-04-26.yang
@@ -1,8 +1,8 @@
-module meta {
+module other {
 
   yang-version "1.1";
 
-  namespace "http://example.com/meta";
+  namespace "http://example.com/other";
 
   prefix "m";
 

--- a/yang-modules/test_metadata/yang-library.json
+++ b/yang-modules/test_metadata/yang-library.json
@@ -1,0 +1,33 @@
+{
+  "ietf-yang-library:modules-state": {
+    "module-set-id": "b6d7e0614440c5ad8a7370fe46c777254d331983",
+    "module": [
+      {
+        "name": "meta",
+        "revision": "2016-04-26",
+        "schema": "https://example.com/meta.yang",
+        "namespace": "http://example.com/meta",
+        "conformance-type": "implement"
+      },
+      {
+        "name": "other",
+        "revision": "2016-04-26",
+        "schema": "https://example.com/other.yang",
+        "namespace": "http://example.com/other",
+        "conformance-type": "implement"
+      },
+      {
+        "name": "ietf-yang-types",
+        "revision": "2013-07-15",
+        "namespace": "urn:ietf:params:xml:ns:yang:ietf-yang-types",
+        "conformance-type": "import"
+      },
+      {
+        "name": "ietf-yang-metadata",
+        "revision": "2016-08-05",
+        "namespace": "urn:ietf:params:xml:ns:yang:ietf-yang-metadata",
+        "conformance-type": "import"
+      }
+    ]
+  }
+}

--- a/yangson/instance.py
+++ b/yangson/instance.py
@@ -378,6 +378,8 @@ class InstanceNode:
         return self.peek(irt)
 
     def _member_schema_node(self, name: InstanceName) -> "DataNode":
+        if name.startswith("@"):
+            return self.schema_node.schema_root()
         qname = self.schema_node._iname2qname(name)
         res = self.schema_node.get_data_child(*qname)
         if res is None:

--- a/yangson/parser.py
+++ b/yangson/parser.py
@@ -39,7 +39,7 @@ class Parser:
 
     # Regular expressions
 
-    ident_re = re.compile("[a-zA-Z_][a-zA-Z0-9_.-]*")
+    ident_re = re.compile(r"(@?[a-zA-Z_][a-zA-Z0-9_.-]*|@)")
     """Regular expression for YANG identifier."""
 
     ws_re = re.compile(r"[ \n\t\r]*")


### PR DESCRIPTION
Hello Lada,

I made some changes to support the metadata/annotation Yang extension.
I implemented it by adding an "annotation" type of node at the root of the model, and by redirecting the data to them when encountering the `@` sign.
Are you interested in adding this?
Do you see issues with the way it is implemented? I probably missed some things.

Best regards,
Iwan