### PR TITLE
Fix parsing XPath expression ending with .

### DIFF
--- a/yang-modules/test/test@2016-04-26.yang
+++ b/yang-modules/test/test@2016-04-26.yang
@@ -100,6 +100,7 @@ module test {
       }
       leaf leafF {
         type boolean;
+        must ".";
       }
       leaf leafW {
 	type d:typE;

--- a/yangson/parser.py
+++ b/yangson/parser.py
@@ -76,6 +76,10 @@ class Parser:
         """Return ``True`` if at end of input."""
         return self.offset >= len(self.input)
 
+    def at_last_char(self) -> bool:
+        """Return ``True`` if at last character of input."""
+        return self.offset == (len(self.input) - 1)
+
     def char(self, c: str) -> None:
         """Parse the specified character.
 

--- a/yangson/xpathparser.py
+++ b/yangson/xpathparser.py
@@ -177,7 +177,8 @@ class XPathParser(Parser):
             self.skip_ws()
             return Literal(val)
         if ("0" <= next <= "9" or
-                next == "." and "0" <= self.input[self.offset + 1] <= "9"):
+                next == "." and not self.at_last_char() and
+                "0" <= self.input[self.offset + 1] <= "9"):
             val = self.unsigned_float()
             self.skip_ws()
             return Number(val)


### PR DESCRIPTION
Hi,

I made a small fix for the XPath parser, if a . is seen, the next character is looked up without checking bounds first, but an XPath expression ending with "." is valid.

Iwan