### PR TITLE
Loop through all fake children

### DIFF
--- a/yangson/schemanode.py
+++ b/yangson/schemanode.py
@@ -347,7 +347,9 @@ class InternalNode(SchemaNode):
             elif child.name == name and child.ns == ns:
                 return child
         for c in todo:
-            return c.get_child(name, ns)
+            grandchild = c.get_child(name, ns)
+            if grandchild is not None:
+                return grandchild
 
     def get_schema_descendant(
             self, route: SchemaRoute) -> Optional[SchemaNode]:


### PR DESCRIPTION
get_child returns too early if there is more than one fake child create to handle the when statements.