### PR TITLE
get_child can return None if there are more than one child

### DIFF
--- a/yangson/schemanode.py
+++ b/yangson/schemanode.py
@@ -359,7 +359,9 @@ class InternalNode(SchemaNode):
             elif child.name == name and child.ns == ns:
                 return child
         for c in todo:
-            return c.get_child(name, ns)
+            grandchild = c.get_child(name, ns)
+            if grandchild is not None:
+                return grandchild
 
     def get_schema_descendant(
             self, route: SchemaRoute) -> Optional[SchemaNode]:


### PR DESCRIPTION
This code loops over grandchildren but it returns the first one, even if it's None.