### PR TITLE
Require bleach 3.1 compatible version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ appdirs==1.4.0
 args==0.1.0
 astroid==1.4.5
 Babel==2.3.3
-bleach==3.1.2
+bleach~=3.1
 certifi==2019.9.11
 chardet==3.0.4
 clint==0.5.1


### PR DESCRIPTION
This is just a suggestion: you can use `~=` operator in requirements file to install version 3.1 or compatible.

This update should install latest release of given package, which will often provide (security) fixes and won't stuck you in some old version of the library.

It should silence Github Security Advisory notification as well.