### PR TITLE
in json_pointer(), remove spurious 'print' statement and add support for LeafListNodes

### DIFF
--- a/yangson/instance.py
+++ b/yangson/instance.py
@@ -185,14 +185,16 @@ class InstanceNode:
         """Return JSON Pointer [RFC6901]_ of the receiver."""
         if not expand_keys:
             return "/" + "/".join(str(c) for c in self.path)
-
         res = []
         inst = self
         while inst.parinst:
-            print(type(inst))
             if isinstance(inst, ArrayEntry):
-                keys = [str(inst.value[k[0]]) for k in inst.schema_node.keys]
-                res.insert(0, inst.schema_node.name + '=' + ','.join(keys))
+                if isinstance(inst.schema_node, ListNode):
+                    keys = [str(inst.value[k[0]]) for k in inst.schema_node.keys]
+                    res.insert(0, inst.schema_node.name + '=' + ','.join(keys))
+                else:
+                    res.insert(0, inst.schema_node.name + '=' + inst.value)
+                inst = inst.parinst
             else:
                 res.insert(0, inst.name)
             inst = inst.parinst


### PR DESCRIPTION
Hi Lada,

I found one issue that I think you'll want to merge ASAP, as it breaks existing code.  The issue is in [this part of the other recently merged PR](https://github.com/CZ-NIC/yangson/commit/63588d9b86566f64ed8ab7bda33e670057a853a4#diff-a78b0789a9fe059933c8d79371f51ddf33046e3faeaeba68271ed507ee0b6bc7).  In addition to the spurious "print" statement, the code neglected to take into account LeafListNodes.  Using this update, all my test cases pass (over 16,000 lines of pytests).

PS: I've just scratched the surface of integrating the new XML code, so more reports may be forthcoming.

Kent
