### PR TITLE
Annotations

### DIFF
--- a/yangson/constraint.py
+++ b/yangson/constraint.py
@@ -24,6 +24,7 @@ This module implements the following classes:
 * Pattern: Class representing regular expression pattern.
 * Must: Class representing the constraint specified by a "must" statement.
 """
+from __future__ import annotations
 
 import decimal
 import re
@@ -44,7 +45,7 @@ Interval = List[Number]
 class Constraint:
     """Abstract class representing annotated YANG constraints."""
 
-    def __init__(self, error_tag: Optional[str], error_message: Optional[str]):
+    def __init__(self: Constraint, error_tag: Optional[str], error_message: Optional[str]):
         """Initialize the class instance."""
         self.error_tag = error_tag
         self.error_message = error_message
@@ -53,7 +54,7 @@ class Constraint:
 class Intervals(Constraint):
     """Class representing a sequence of numeric intervals."""
 
-    def __init__(self, intervals: List[Interval],
+    def __init__(self: Intervals, intervals: List[Interval],
                  parser: Callable[[str], Optional[Number]] = None,
                  error_tag: str = None, error_message: str = None):
         """Initialize the class instance."""
@@ -66,7 +67,7 @@ class Intervals(Constraint):
         self.intervals = intervals
         self.parser = parser if parser else _pint
 
-    def __contains__(self, value: Number):
+    def __contains__(self: Intervals, value: Number):
         """Return ``True`` if the receiver contains the value."""
         for r in self.intervals:
             if len(r) == 1:
@@ -76,12 +77,12 @@ class Intervals(Constraint):
                 return True
         return False
 
-    def __str__(self) -> str:
+    def __str__(self: Intervals) -> str:
         """Return string representation of the receiver."""
         return " | ".join([f"{r[0]!s}..{r[-1]!s}" if len(r) > 1 else str(r[0])
                            for r in self.intervals])
 
-    def restrict_with(self, expr: str, error_tag: str = None,
+    def restrict_with(self: Intervals, expr: str, error_tag: str = None,
                       error_message: str = None) -> None:
         """Combine the receiver with new intervals.
 
@@ -129,7 +130,7 @@ class Intervals(Constraint):
 class Pattern(Constraint):
     """Class representing regular expression pattern."""
 
-    def __init__(self, pattern: str, invert_match: bool = False,
+    def __init__(self: Pattern, pattern: str, invert_match: bool = False,
                  error_tag: str = None,
                  error_message: str = None):
         """Initialize the class instance."""
@@ -146,7 +147,7 @@ class Pattern(Constraint):
 class Must(Constraint):
     """Class representing the constraint specified by a "must" statement."""
 
-    def __init__(self, expression: Expr, error_tag: str = None,
+    def __init__(self: Must, expression: Expr, error_tag: str = None,
                  error_message: str = None):
         """Initialize the class instance."""
         super().__init__(

--- a/yangson/datamodel.py
+++ b/yangson/datamodel.py
@@ -21,6 +21,7 @@ This module implements the following class:
 
 * DataModel: Basic entry point to the YANG data model.
 """
+from __future__ import annotations
 
 import hashlib
 import json
@@ -58,7 +59,7 @@ class DataModel:
             yltxt = infile.read()
         return cls(yltxt, mod_path, description)
 
-    def __init__(self, yltxt: str, mod_path: Tuple[str] = (".",),
+    def __init__(self: DataModel, yltxt: str, mod_path: Tuple[str] = (".",),
                  description: str = None):
         """Initialize the class instance.
 
@@ -89,7 +90,7 @@ class DataModel:
             self.yang_library["ietf-yang-library:modules-state"]
             ["module-set-id"])
 
-    def module_set_id(self) -> str:
+    def module_set_id(self: DataModel) -> str:
         """Compute unique id of YANG modules comprising the data model.
 
         Returns:
@@ -98,7 +99,7 @@ class DataModel:
         fnames = sorted(["@".join(m) for m in self.schema_data.modules])
         return hashlib.sha1("".join(fnames).encode("ascii")).hexdigest()
 
-    def from_raw(self, robj: RawObject) -> RootNode:
+    def from_raw(self: DataModel, robj: RawObject) -> RootNode:
         """Create an instance node from a raw data tree.
 
         Args:
@@ -110,7 +111,7 @@ class DataModel:
         cooked = self.schema.from_raw(robj)
         return RootNode(cooked, self.schema, self.schema_data, cooked.timestamp)
 
-    def from_xml(self, root: ET.Element) -> RootNode:
+    def from_xml(self: DataModel, root: ET.Element) -> RootNode:
         """Create an instance node from a raw data tree.
 
         Args:
@@ -122,7 +123,7 @@ class DataModel:
         cooked = self.schema.from_xml(root)
         return RootNode(cooked, self.schema, self.schema_data, cooked.timestamp)
 
-    def get_schema_node(self, path: SchemaPath) -> Optional[SchemaNode]:
+    def get_schema_node(self: DataModel, path: SchemaPath) -> Optional[SchemaNode]:
         """Return the schema node addressed by a schema path.
 
         Args:
@@ -137,7 +138,7 @@ class DataModel:
         return self.schema.get_schema_descendant(
             self.schema_data.path2route(path))
 
-    def get_data_node(self, path: DataPath) -> Optional[DataNode]:
+    def get_data_node(self: DataModel, path: DataPath) -> Optional[DataNode]:
         """Return the data node addressed by a data path.
 
         Args:
@@ -157,7 +158,7 @@ class DataModel:
                 return None
         return node
 
-    def ascii_tree(self, no_types: bool = False, val_count: bool = False) -> str:
+    def ascii_tree(self: DataModel, no_types: bool = False, val_count: bool = False) -> str:
         """Generate ASCII art representation of the schema tree.
 
         Args:
@@ -169,17 +170,17 @@ class DataModel:
         """
         return self.schema._ascii_tree("", no_types, val_count)
 
-    def clear_val_counters(self):
+    def clear_val_counters(self: DataModel):
         """Clear validation counters in the entire schema tree."""
         self.schema.clear_val_counters()
 
-    def parse_instance_id(self, text: str) -> InstanceRoute:
+    def parse_instance_id(self: DataModel, text: str) -> InstanceRoute:
         return InstanceIdParser(text).parse()
 
-    def parse_resource_id(self, text: str) -> InstanceRoute:
+    def parse_resource_id(self: DataModel, text: str) -> InstanceRoute:
         return ResourceIdParser(text, self.schema).parse()
 
-    def schema_digest(self) -> str:
+    def schema_digest(self: DataModel) -> str:
         """Generate schema digest (to be used primarily by clients).
 
         Returns:
@@ -189,7 +190,7 @@ class DataModel:
         res["config"] = True
         return json.dumps(res)
 
-    def _build_schema(self) -> None:
+    def _build_schema(self: DataModel) -> None:
         for mid in self.schema_data._module_sequence:
             sctx = SchemaContext(
                 self.schema_data, self.schema_data.namespace(mid), mid)

--- a/yangson/datatype.py
+++ b/yangson/datatype.py
@@ -43,6 +43,7 @@ This module implements the following classes:
 * Uint64Type: YANG uint64 type.
 * UnionType: YANG union type.
 """
+from __future__ import annotations
 
 import base64
 import decimal
@@ -69,7 +70,7 @@ class DataType:
 
     _option_template = '<option value="{}"{}>{}</option>'
 
-    def __init__(self, sctx: SchemaContext, name: Optional[YangIdentifier]):
+    def __init__(self: DataType, sctx: SchemaContext, name: Optional[YangIdentifier]):
         """Initialize the class instance."""
         self.sctx = sctx
         self.default = None
@@ -77,7 +78,7 @@ class DataType:
         self.error_tag = None
         self.error_message = None
 
-    def __contains__(self, val: ScalarValue) -> bool:
+    def __contains__(self: DataType, val: ScalarValue) -> bool:
         """Return ``True`` if the receiver type contains `val`.
 
         If the result is ``False``, set also `error_tag` and `error_message`
@@ -85,12 +86,12 @@ class DataType:
         """
         return True
 
-    def __str__(self):
+    def __str__(self: DataType):
         """Return YANG name of the receiver type."""
         base = self.yang_type()
         return f"{self.name}({base})" if self.name else base
 
-    def from_raw(self, raw: RawScalar) -> Optional[ScalarValue]:
+    def from_raw(self: DataType, raw: RawScalar) -> Optional[ScalarValue]:
         """Return a cooked value of the receiver type.
 
         The input argument should follow the rules for JSON
@@ -105,7 +106,7 @@ class DataType:
         if isinstance(raw, str):
             return raw
 
-    def from_xml(self, xml: ET.Element) -> Optional[ScalarValue]:
+    def from_xml(self: DataType, xml: ET.Element) -> Optional[ScalarValue]:
         """Return a cooked value of the received XML type.
 
         Args:
@@ -114,15 +115,15 @@ class DataType:
         if isinstance(xml.text, str):
             return xml.text
 
-    def to_raw(self, val: ScalarValue) -> Optional[RawScalar]:
+    def to_raw(self: DataType, val: ScalarValue) -> Optional[RawScalar]:
         """Return a raw value ready to be serialized in JSON."""
         return val
 
-    def to_xml(self, val: ScalarValue) -> Optional[str]:
+    def to_xml(self: DataType, val: ScalarValue) -> Optional[str]:
         """Return XML text value ready to be serialized in XML."""
         return str(val)
 
-    def parse_value(self, text: str) -> Optional[ScalarValue]:
+    def parse_value(self: DataType, text: str) -> Optional[ScalarValue]:
         """Parse value of the receiver's type.
 
         The input text should follow the rules for lexical
@@ -139,11 +140,11 @@ class DataType:
         """
         return self.from_raw(text)
 
-    def canonical_string(self, val: ScalarValue) -> Optional[str]:
+    def canonical_string(self: DataType, val: ScalarValue) -> Optional[str]:
         """Return canonical form of a value."""
         return str(val)
 
-    def from_yang(self, text: str) -> ScalarValue:
+    def from_yang(self: DataType, text: str) -> ScalarValue:
         """Parse value specified as default in a YANG module.
 
         Conformance to the receiving type isn't guaranteed.
@@ -159,16 +160,16 @@ class DataType:
             raise InvalidArgument(text)
         return res
 
-    def yang_type(self) -> YangIdentifier:
+    def yang_type(self: DataType) -> YangIdentifier:
         """Return YANG name of the receiver."""
         return self.__class__.__name__[:-4].lower()
 
-    def _set_error_info(self, error_tag: str = None, error_message: str = None):
+    def _set_error_info(self: DataType, error_tag: str = None, error_message: str = None):
         self.error_tag = error_tag if error_tag else "invalid-type"
         self.error_message = (error_message if error_message else
                               "expected " + str(self))
 
-    def _post_process(self, tnode: "TerminalNode") -> None:
+    def _post_process(self: DataType, tnode: "TerminalNode") -> None:
         """Post-process the receiver type on behalf of a terminal node.
 
         By default do nothing.
@@ -215,18 +216,18 @@ class DataType:
         res._handle_restrictions(stmt, sctx)
         return res
 
-    def _deref(self, node: InstanceNode) -> List[InstanceNode]:
+    def _deref(self: DataType, node: InstanceNode) -> List[InstanceNode]:
         return []
 
-    def _handle_properties(self, stmt: Statement, sctx: SchemaContext) -> None:
+    def _handle_properties(self: DataType, stmt: Statement, sctx: SchemaContext) -> None:
         """Handle type substatements."""
         self._handle_restrictions(stmt, sctx)
 
-    def _handle_restrictions(self, stmt: Statement, sctx: SchemaContext) -> None:
+    def _handle_restrictions(self: DataType, stmt: Statement, sctx: SchemaContext) -> None:
         """Handle type restriction substatements."""
         pass
 
-    def _type_digest(self, config: bool) -> Dict[str, Any]:
+    def _type_digest(self: DataType, config: bool) -> Dict[str, Any]:
         """Return receiver's type digest.
 
         Args:
@@ -241,72 +242,72 @@ class DataType:
 class EmptyType(DataType):
     """Class representing YANG "empty" type."""
 
-    def canonical_string(self, val: Tuple[None]) -> Optional[str]:
+    def canonical_string(self: EmptyType, val: Tuple[None]) -> Optional[str]:
         return ""
 
-    def __contains__(self, val: Tuple[None]) -> bool:
+    def __contains__(self: EmptyType, val: Tuple[None]) -> bool:
         if val == (None,):
             return True
         self._set_error_info()
         return False
 
-    def parse_value(self, text: str) -> Optional[Tuple[None]]:
+    def parse_value(self: EmptyType, text: str) -> Optional[Tuple[None]]:
         if text == "":
             return (None,)
 
-    def from_raw(self, raw: RawScalar) -> Optional[Tuple[None]]:
+    def from_raw(self: EmptyType, raw: RawScalar) -> Optional[Tuple[None]]:
         if raw == [None]:
             return (None,)
 
-    def to_raw(self, val: Tuple[None]) -> List[None]:
+    def to_raw(self: EmptyType, val: Tuple[None]) -> List[None]:
         return [None]
 
-    def from_xml(self, xml: str) -> Optional[Tuple[None]]:
+    def from_xml(self: EmptyType, xml: str) -> Optional[Tuple[None]]:
         if xml == '':
             return (None,)
 
-    def to_xml(self, val: Tuple[None]) -> None:
+    def to_xml(self: EmptyType, val: Tuple[None]) -> None:
         return None
 
 
 class BitsType(DataType):
     """Class representing YANG "bits" type."""
 
-    def __init__(self, sctx: SchemaContext, name: YangIdentifier):
+    def __init__(self: BitsType, sctx: SchemaContext, name: YangIdentifier):
         """Initialize the class instance."""
         super().__init__(sctx, name)
         self.bit = {}
 
-    def sorted_bits(self) -> List[Tuple[str, int]]:
+    def sorted_bits(self: BitsType) -> List[Tuple[str, int]]:
         """Return list of bit items sorted by position."""
         return sorted(self.bit.items(), key=lambda x: x[1])
 
-    def from_raw(self, raw: RawScalar) -> Optional[Tuple[str]]:
+    def from_raw(self: BitsType, raw: RawScalar) -> Optional[Tuple[str]]:
         try:
             return tuple(raw.split())
         except AttributeError:
             return None
 
-    def from_xml(self, xml: ET.Element) -> Optional[Tuple[str]]:
+    def from_xml(self: BitsType, xml: ET.Element) -> Optional[Tuple[str]]:
         try:
             return tuple(xml.text.split())
         except AttributeError:
             return None
 
-    def __contains__(self, val: Tuple[str]) -> bool:
+    def __contains__(self: BitsType, val: Tuple[str]) -> bool:
         for b in val:
             if b not in self.bit:
                 self._set_error_info(error_message="unknown bit " + b)
                 return False
         return True
 
-    def to_raw(self, val: Tuple[str]) -> str:
+    def to_raw(self: BitsType, val: Tuple[str]) -> str:
         return self.canonical_string(val)
 
-    def to_xml(self, val: Tuple[str]) -> str:
+    def to_xml(self: BitsType, val: Tuple[str]) -> str:
         return self.canonical_string(val)
 
-    def as_int(self, val: Tuple[str]) -> int:
+    def as_int(self: BitsType, val: Tuple[str]) -> int:
         """Transform a "bits" value to an integer."""
         res = 0
         try:
@@ -316,7 +317,7 @@ class BitsType(DataType):
             return None
         return res
 
-    def canonical_string(self, val: Tuple[str]) -> Optional[str]:
+    def canonical_string(self: BitsType, val: Tuple[str]) -> Optional[str]:
         try:
             items = [(self.bit[b], b) for b in val]
         except KeyError:
@@ -324,7 +325,7 @@ class BitsType(DataType):
         items.sort()
         return " ".join([x[1] for x in items])
 
-    def _handle_properties(self, stmt: Statement, sctx: SchemaContext) -> None:
+    def _handle_properties(self: BitsType, stmt: Statement, sctx: SchemaContext) -> None:
         """Handle **bit** statements."""
         nextpos = 0
         for bst in stmt.find_all("bit"):
@@ -341,7 +342,7 @@ class BitsType(DataType):
                 self.bit[label] = nextpos
             nextpos += 1
 
-    def _handle_restrictions(self, stmt: Statement, sctx: SchemaContext) -> None:
+    def _handle_restrictions(self: BitsType, stmt: Statement, sctx: SchemaContext) -> None:
         bst = stmt.find_all("bit")
         if not bst:
             return
@@ -350,7 +351,7 @@ class BitsType(DataType):
         for bit in set(self.bit) - new:
             del self.bit[bit]
 
-    def _type_digest(self, config: bool) -> Dict[str, Any]:
+    def _type_digest(self: BitsType, config: bool) -> Dict[str, Any]:
         res = super()._type_digest(config)
         bits = []
         i = 0
@@ -366,18 +367,18 @@ class BitsType(DataType):
 class BooleanType(DataType):
     """Class representing YANG "boolean" type."""
 
-    def __contains__(self, val: bool) -> bool:
+    def __contains__(self: BooleanType, val: bool) -> bool:
         if isinstance(val, bool):
             return True
         self._set_error_info()
         return False
 
-    def from_raw(self, raw: RawScalar) -> Optional[bool]:
+    def from_raw(self: BooleanType, raw: RawScalar) -> Optional[bool]:
         """Override superclass method."""
         if isinstance(raw, bool):
             return raw
 
-    def from_xml(self, xml: ET.Element) -> Optional[ScalarValue]:
+    def from_xml(self: BooleanType, xml: ET.Element) -> Optional[ScalarValue]:
         """Return a cooked value of the received XML type.
 
         Args:
@@ -385,7 +386,7 @@ class BooleanType(DataType):
         """
         return self.parse_value(xml.text)
 
-    def parse_value(self, text: str) -> Optional[bool]:
+    def parse_value(self: BooleanType, text: str) -> Optional[bool]:
         """Parse boolean value.
 
         Args:
@@ -396,7 +397,7 @@ class BooleanType(DataType):
         if text == "false":
             return False
 
-    def canonical_string(self, val: bool) -> Optional[str]:
+    def canonical_string(self: BooleanType, val: bool) -> Optional[str]:
         if val is True:
             return "true"
         if val is False:
@@ -406,12 +407,12 @@ class BooleanType(DataType):
 class LinearType(DataType):
     """Abstract class representing character or byte sequences."""
 
-    def __init__(self, sctx: SchemaContext, name: YangIdentifier):
+    def __init__(self: LinearType, sctx: SchemaContext, name: YangIdentifier):
         """Initialize the class instance."""
         super().__init__(sctx, name)
         self.length = None  # type: Optional[Intervals]
 
-    def _handle_restrictions(self, stmt: Statement, sctx: SchemaContext) -> None:
+    def _handle_restrictions(self: LinearType, stmt: Statement, sctx: SchemaContext) -> None:
         lstmt = stmt.find1("length")
         if lstmt:
             if self.length is None:
@@ -419,13 +420,13 @@ class LinearType(DataType):
                     [[0, 4294967295]], error_message="invalid length")
             self.length.restrict_with(lstmt.argument, *lstmt.get_error_info())
 
-    def __contains__(self, val: Union[str, bytes]) -> bool:
+    def __contains__(self: LinearType, val: Union[str, bytes]) -> bool:
         if self.length and len(val) not in self.length:
             self._set_error_info(self.length.error_tag, self.length.error_message)
             return False
         return True
 
-    def _type_digest(self, config: bool) -> Dict[str, Any]:
+    def _type_digest(self: LinearType, config: bool) -> Dict[str, Any]:
         res = super()._type_digest(config)
         if self.length:
             res["length"] = self.length.intervals
@@ -435,19 +436,19 @@ class LinearType(DataType):
 class StringType(LinearType):
     """Class representing YANG "string" type."""
 
-    def __init__(self, sctx: SchemaContext, name: YangIdentifier):
+    def __init__(self: StringType, sctx: SchemaContext, name: YangIdentifier):
         """Initialize the class instance."""
         super().__init__(sctx, name)
         self.patterns = []  # type: List[Pattern]
 
-    def _handle_restrictions(self, stmt: Statement, sctx: SchemaContext) -> None:
+    def _handle_restrictions(self: StringType, stmt: Statement, sctx: SchemaContext) -> None:
         super()._handle_restrictions(stmt, sctx)
         for pst in stmt.find_all("pattern"):
             invm = pst.find1("modifier", "invert-match") is not None
             self.patterns.append(Pattern(
                 pst.argument, invm, *pst.get_error_info()))
 
-    def __contains__(self, val: str) -> bool:
+    def __contains__(self: StringType, val: str) -> bool:
         if not isinstance(val, str):
             self._set_error_info()
             return False
@@ -459,7 +460,7 @@ class StringType(LinearType):
                 return False
         return True
 
-    def _type_digest(self, config: bool) -> Dict[str, Any]:
+    def _type_digest(self: StringType, config: bool) -> Dict[str, Any]:
         res = super()._type_digest(config)
         pats = [p.pattern for p in self.patterns if not p.invert_match]
         ipats = [p.pattern for p in self.patterns if p.invert_match]
@@ -473,55 +474,55 @@ class StringType(LinearType):
 class BinaryType(LinearType):
     """Class representing YANG "binary" type."""
 
-    def from_raw(self, raw: RawScalar) -> Optional[bytes]:
+    def from_raw(self: BinaryType, raw: RawScalar) -> Optional[bytes]:
         """Override superclass method."""
         try:
             return base64.b64decode(raw, validate=True)
         except TypeError:
             return None
 
-    def from_xml(self, xml: ET.Element) -> Optional[bytes]:
+    def from_xml(self: BinaryType, xml: ET.Element) -> Optional[bytes]:
         """Override superclass method."""
         try:
             return base64.b64decode(xml.text, validate=True)
         except TypeError:
             return None
 
-    def __contains__(self, val: bytes) -> bool:
+    def __contains__(self: BinaryType, val: bytes) -> bool:
         if not isinstance(val, bytes):
             self._set_error_info()
             return False
         return super().__contains__(val)
 
-    def to_raw(self, val: bytes) -> str:
+    def to_raw(self: BinaryType, val: bytes) -> str:
         return self.canonical_string(val)
 
-    def to_xml(self, val: bytes) -> str:
+    def to_xml(self: BinaryType, val: bytes) -> str:
         return self.canonical_string(val)
 
-    def canonical_string(self, val: bytes) -> Optional[str]:
+    def canonical_string(self: BinaryType, val: bytes) -> Optional[str]:
         return base64.b64encode(val).decode("ascii")
 
 
 class EnumerationType(DataType):
     """Class representing YANG "enumeration" type."""
 
-    def __init__(self, sctx: SchemaContext, name: YangIdentifier):
+    def __init__(self: EnumerationType, sctx: SchemaContext, name: YangIdentifier):
         """Initialize the class instance."""
         super().__init__(sctx, name)
         self.enum = {}  # type: Dict[str, int]
 
-    def sorted_enums(self) -> List[Tuple[str, int]]:
+    def sorted_enums(self: EnumerationType) -> List[Tuple[str, int]]:
         """Return list of enum items sorted by value."""
         return sorted(self.enum.items(), key=lambda x: x[1])
 
-    def __contains__(self, val: str) -> bool:
+    def __contains__(self: EnumerationType, val: str) -> bool:
         if val in self.enum:
             return True
         self._set_error_info()
         return False
 
-    def _handle_properties(self, stmt: Statement, sctx: SchemaContext) -> None:
+    def _handle_properties(self: EnumerationType, stmt: Statement, sctx: SchemaContext) -> None:
         """Handle **enum** statements."""
         nextval = 0
         for est in stmt.find_all("enum"):
@@ -538,7 +539,7 @@ class EnumerationType(DataType):
                 self.enum[label] = nextval
             nextval += 1
 
-    def _handle_restrictions(self, stmt: Statement, sctx: SchemaContext) -> None:
+    def _handle_restrictions(self: EnumerationType, stmt: Statement, sctx: SchemaContext) -> None:
         est = stmt.find_all("enum")
         if not est:
             return
@@ -547,7 +548,7 @@ class EnumerationType(DataType):
         for en in set(self.enum) - new:
             del self.enum[en]
 
-    def _type_digest(self, config: bool) -> Dict[str, Any]:
+    def _type_digest(self: EnumerationType, config: bool) -> Dict[str, Any]:
         res = super()._type_digest(config)
         if config:
             res["enums"] = list(self.enum.keys())
@@ -557,12 +558,12 @@ class EnumerationType(DataType):
 class LinkType(DataType):
     """Abstract class for instance-referencing types."""
 
-    def __init__(self, sctx: SchemaContext, name: YangIdentifier):
+    def __init__(self: LinkType, sctx: SchemaContext, name: YangIdentifier):
         """Initialize the class instance."""
         super().__init__(sctx, name)
         self.require_instance = True  # type: bool
 
-    def _handle_restrictions(self, stmt: Statement, sctx: SchemaContext) -> None:
+    def _handle_restrictions(self: LinkType, stmt: Statement, sctx: SchemaContext) -> None:
         if stmt.find1("require-instance", "false"):
             self.require_instance = False
 
@@ -570,52 +571,52 @@ class LinkType(DataType):
 class LeafrefType(LinkType):
     """Class representing YANG "leafref" type."""
 
-    def __init__(self, sctx: SchemaContext, name: YangIdentifier):
+    def __init__(self: LeafrefType, sctx: SchemaContext, name: YangIdentifier):
         """Initialize the class instance."""
         super().__init__(sctx, name)
         self.path = None
         self.ref_type = None
 
-    def _handle_properties(self, stmt: Statement, sctx: SchemaContext) -> None:
+    def _handle_properties(self: LeafrefType, stmt: Statement, sctx: SchemaContext) -> None:
         super()._handle_properties(stmt, sctx)
         self.path = XPathParser(
             stmt.find1("path", required=True).argument, sctx).parse()
 
-    def canonical_string(self, val: ScalarValue) -> Optional[str]:
+    def canonical_string(self: LeafrefType, val: ScalarValue) -> Optional[str]:
         return self.ref_type.canonical_string(val)
 
-    def __contains__(self, val: ScalarValue) -> bool:
+    def __contains__(self: LeafrefType, val: ScalarValue) -> bool:
         return val in self.ref_type
 
-    def from_raw(self, raw: RawScalar) -> Optional[ScalarValue]:
+    def from_raw(self: LeafrefType, raw: RawScalar) -> Optional[ScalarValue]:
         return self.ref_type.from_raw(raw)
 
-    def from_xml(self, xml: ET.Element) -> Optional[bytes]:
+    def from_xml(self: LeafrefType, xml: ET.Element) -> Optional[bytes]:
         return self.ref_type.from_xml(xml)
 
-    def to_raw(self, val: ScalarValue) -> RawScalar:
+    def to_raw(self: LeafrefType, val: ScalarValue) -> RawScalar:
         return self.ref_type.to_raw(val)
 
-    def to_xml(self, val: ScalarValue) -> RawScalar:
+    def to_xml(self: LeafrefType, val: ScalarValue) -> RawScalar:
         return self.ref_type.to_xml(val)
 
-    def parse_value(self, text: str) -> Optional[ScalarValue]:
+    def parse_value(self: LeafrefType, text: str) -> Optional[ScalarValue]:
         return self.ref_type.parse_value(text)
 
-    def from_yang(self, text: str) -> ScalarValue:
+    def from_yang(self: LeafrefType, text: str) -> ScalarValue:
         return self.ref_type.from_yang(text)
 
-    def _deref(self, node: InstanceNode) -> List[InstanceNode]:
+    def _deref(self: LeafrefType, node: InstanceNode) -> List[InstanceNode]:
         ns = self.path.evaluate(node)
         return [n for n in ns if str(n) == str(node)]
 
-    def _post_process(self, tnode: "TerminalNode") -> None:
+    def _post_process(self: LeafrefType, tnode: "TerminalNode") -> None:
         ref = tnode._follow_leafref(self.path, tnode)
         if ref is None:
             raise InvalidLeafrefPath(tnode.qual_name)
         self.ref_type = ref.type
 
-    def _type_digest(self, config: bool) -> Dict[str, Any]:
+    def _type_digest(self: LeafrefType, config: bool) -> Dict[str, Any]:
         res = super()._type_digest(config)
         res["ref_type"] = self.ref_type._type_digest(config)
         return res
@@ -624,54 +625,54 @@ class LeafrefType(LinkType):
 class InstanceIdentifierType(LinkType):
     """Class representing YANG "instance-identifier" type."""
 
-    def __str__(self):
+    def __str__(self: InstanceIdentifierType):
         return "instance-identifier"
 
-    def yang_type(self) -> YangIdentifier:
+    def yang_type(self: InstanceIdentifierType) -> YangIdentifier:
         """Override the superclass method."""
         return "instance-identifier"
 
-    def from_raw(self, raw: RawScalar) -> Optional[InstanceRoute]:
+    def from_raw(self: InstanceIdentifierType, raw: RawScalar) -> Optional[InstanceRoute]:
         try:
             return InstanceIdParser(raw).parse()
         except ParserException:
             return None
 
-    def from_xml(self, xml: ET.Element) -> Optional[InstanceRoute]:
+    def from_xml(self: InstanceIdentifierType, xml: ET.Element) -> Optional[InstanceRoute]:
         return self.from_raw(xml.text)
 
-    def to_raw(self, val: InstanceRoute) -> str:
+    def to_raw(self: InstanceIdentifierType, val: InstanceRoute) -> str:
         """Override the superclass method."""
         return str(val)
 
-    def to_xml(self, val: InstanceRoute) -> str:
+    def to_xml(self: InstanceIdentifierType, val: InstanceRoute) -> str:
         """Override the superclass method."""
         return str(val)
 
-    def from_yang(self, text: str) -> InstanceRoute:
+    def from_yang(self: InstanceIdentifierType, text: str) -> InstanceRoute:
         """Override the superclass method."""
         return XPathParser(text, self.sctx).parse().as_instance_route()
 
-    def _deref(self, node: InstanceNode) -> List[InstanceNode]:
+    def _deref(self: InstanceIdentifierType, node: InstanceNode) -> List[InstanceNode]:
         return [node.top().goto(node.value)]
 
 
 class IdentityrefType(DataType):
     """Class representing YANG "identityref" type."""
 
-    def __init__(self, sctx: SchemaContext, name: YangIdentifier):
+    def __init__(self: IdentityrefType, sctx: SchemaContext, name: YangIdentifier):
         """Initialize the class instance."""
         super().__init__(sctx, name)
         self.bases = []  # type: List[QualName]
 
-    def from_raw(self, raw: RawScalar) -> Optional[QualName]:
+    def from_raw(self: IdentityrefType, raw: RawScalar) -> Optional[QualName]:
         try:
             i1, s, i2 = raw.partition(":")
         except AttributeError:
             return None
         return (i2, i1) if s else (i1, self.sctx.default_ns)
 
-    def from_xml(self, xml: ET.Element) -> Optional[QualName]:
+    def from_xml(self: IdentityrefType, xml: ET.Element) -> Optional[QualName]:
         try:
             i1, s, i2 = xml.text.partition(":")
         except AttributeError:
@@ -687,20 +688,20 @@ class IdentityrefType(DataType):
             raise MissingModuleNamespace(ns_url)
         return (i2, module.main_module[0])
 
-    def __contains__(self, val: QualName) -> bool:
+    def __contains__(self: IdentityrefType, val: QualName) -> bool:
         for b in self.bases:
             if not self.sctx.schema_data.is_derived_from(val, b):
                 self._set_error_info(error_message=f"not derived from {b[1]}:{b[0]}")
                 return False
         return True
 
-    def to_raw(self, val: QualName) -> str:
+    def to_raw(self: IdentityrefType, val: QualName) -> str:
         return self.canonical_string(val)
 
-    def to_xml(self, val: QualName) -> str:
+    def to_xml(self: IdentityrefType, val: QualName) -> str:
         return self.canonical_string(val)
 
-    def from_yang(self, text: str) -> QualName:
+    def from_yang(self: IdentityrefType, text: str) -> QualName:
         """Override the superclass method."""
         try:
             return self.sctx.schema_data.translate_pname(
@@ -708,17 +709,17 @@ class IdentityrefType(DataType):
         except (ModuleNotRegistered, UnknownPrefix):
             raise InvalidArgument(text)
 
-    def canonical_string(self, val: ScalarValue) -> Optional[str]:
+    def canonical_string(self: IdentityrefType, val: ScalarValue) -> Optional[str]:
         """Return canonical form of a value."""
         return f"{val[1]}:{val[0]}"
 
-    def _handle_properties(self, stmt: Statement, sctx: SchemaContext) -> None:
+    def _handle_properties(self: IdentityrefType, stmt: Statement, sctx: SchemaContext) -> None:
         self.bases = []
         for b in stmt.find_all("base"):
             self.bases.append(
                 sctx.schema_data.translate_pname(b.argument, sctx.text_mid))
 
-    def _type_digest(self, config: bool) -> Dict[str, Any]:
+    def _type_digest(self: IdentityrefType, config: bool) -> Dict[str, Any]:
         res = super()._type_digest(config)
         if config:
             res["identities"] = list(
@@ -729,12 +730,12 @@ class IdentityrefType(DataType):
 class NumericType(DataType):
     """Abstract class for numeric data types."""
 
-    def __init__(self, sctx: SchemaContext, name: YangIdentifier):
+    def __init__(self: NumericType, sctx: SchemaContext, name: YangIdentifier):
         """Initialize the class instance."""
         super().__init__(sctx, name)
         self.range = None  # type: Optional[Intervals]
 
-    def __contains__(self, val: Union[int, decimal.Decimal]) -> bool:
+    def __contains__(self: NumericType, val: Union[int, decimal.Decimal]) -> bool:
         if self.range is None:
             if self._range[0] <= val <= self._range[1]:
                 return True
@@ -746,7 +747,7 @@ class NumericType(DataType):
         self._set_error_info(self.range.error_tag, self.range.error_message)
         return False
 
-    def _handle_restrictions(self, stmt: Statement, sctx: SchemaContext) -> None:
+    def _handle_restrictions(self: NumericType, stmt: Statement, sctx: SchemaContext) -> None:
         rstmt = stmt.find1("range")
         if rstmt:
             if self.range is None:
@@ -754,7 +755,7 @@ class NumericType(DataType):
                                        error_message="not in range")
             self.range.restrict_with(rstmt.argument, *rstmt.get_error_info())
 
-    def _type_digest(self, config: bool) -> Dict[str, Any]:
+    def _type_digest(self: NumericType, config: bool) -> Dict[str, Any]:
         res = super()._type_digest(config)
         if self.range:
             res["range"] = [[self.to_raw(r[0]), self.to_raw(r[-1])]
@@ -765,24 +766,24 @@ class NumericType(DataType):
 class Decimal64Type(NumericType):
     """Class representing YANG "decimal64" type."""
 
-    def __init__(self, sctx: SchemaContext, name: YangIdentifier):
+    def __init__(self: Decimal64Type, sctx: SchemaContext, name: YangIdentifier):
         """Initialize the class instance."""
         super().__init__(sctx, name)
         self._epsilon = decimal.Decimal(0)  # type: decimal.Decimal
 
     @property
-    def _range(self) -> List[decimal.Decimal]:
+    def _range(self: Decimal64Type) -> List[decimal.Decimal]:
         quot = decimal.Decimal(10**self.fraction_digits)
         lim = decimal.Decimal(9223372036854775808)
         return [-lim / quot, (lim - 1) / quot]
 
-    def _handle_properties(self, stmt: Statement, sctx: SchemaContext) -> None:
+    def _handle_properties(self: Decimal64Type, stmt: Statement, sctx: SchemaContext) -> None:
         self.fraction_digits = int(
             stmt.find1("fraction-digits", required=True).argument)
         self._epsilon = decimal.Decimal(10) ** -self.fraction_digits
         super()._handle_properties(stmt, sctx)
 
-    def from_raw(self, raw: RawScalar) -> Optional[decimal.Decimal]:
+    def from_raw(self: Decimal64Type, raw: RawScalar) -> Optional[decimal.Decimal]:
         """Override superclass method.
 
         According to [RFC7951]_, a raw instance must be string.
@@ -794,31 +795,31 @@ class Decimal64Type(NumericType):
         except decimal.InvalidOperation:
             return None
 
-    def from_xml(self, xml: ET.Element) -> Optional[decimal.Decimal]:
+    def from_xml(self: Decimal64Type, xml: ET.Element) -> Optional[decimal.Decimal]:
         try:
             return decimal.Decimal(xml.text).quantize(self._epsilon)
         except decimal.InvalidOperation:
             return None
 
-    def to_raw(self, val: decimal.Decimal) -> str:
+    def to_raw(self: Decimal64Type, val: decimal.Decimal) -> str:
         return self.canonical_string(val)
 
-    def to_xml(self, val: decimal.Decimal) -> str:
+    def to_xml(self: Decimal64Type, val: decimal.Decimal) -> str:
         return self.canonical_string(val)
 
-    def canonical_string(self, val: decimal.Decimal) -> Optional[str]:
+    def canonical_string(self: Decimal64Type, val: decimal.Decimal) -> Optional[str]:
         if val == 0:
             return "0.0"
         sval = str(val.quantize(self._epsilon)).rstrip("0")
         return (sval + "0") if sval.endswith(".") else sval
 
-    def __contains__(self, val: decimal.Decimal) -> bool:
+    def __contains__(self: Decimal64Type, val: decimal.Decimal) -> bool:
         if not isinstance(val, decimal.Decimal):
             self._set_error_info()
             return False
         return super().__contains__(val)
 
-    def _type_digest(self, config: bool) -> Dict[str, Any]:
+    def _type_digest(self: Decimal64Type, config: bool) -> Dict[str, Any]:
         res = super()._type_digest(config)
         res["fraction_digits"] = self.fraction_digits
         return res
@@ -830,20 +831,20 @@ class IntegralType(NumericType):
     octhex = re.compile("[-+]?0([x0-9])")
     """Regular expression for octal or hexadecimal default."""
 
-    def __contains__(self, val: int) -> bool:
+    def __contains__(self: IntegralType, val: int) -> bool:
         if not isinstance(val, int) or isinstance(val, bool):
             self._set_error_info()
             return False
         return super().__contains__(val)
 
-    def parse_value(self, text: str) -> Optional[int]:
+    def parse_value(self: IntegralType, text: str) -> Optional[int]:
         """Override superclass method."""
         try:
             return int(text)
         except ValueError:
             return None
 
-    def from_raw(self, raw: RawScalar) -> Optional[int]:
+    def from_raw(self: IntegralType, raw: RawScalar) -> Optional[int]:
         if not isinstance(raw, int) or isinstance(raw, bool):
             return None
         try:
@@ -851,13 +852,13 @@ class IntegralType(NumericType):
         except (ValueError, TypeError):
             return None
 
-    def from_xml(self, xml: ET.Element) -> Optional[int]:
+    def from_xml(self: IntegralType, xml: ET.Element) -> Optional[int]:
         try:
             return int(xml.text)
         except (ValueError, TypeError):
             return None
 
-    def from_yang(self, text: str) -> int:
+    def from_yang(self: IntegralType, text: str) -> int:
         """Override the superclass method."""
         mo = self.octhex.match(text)
         if mo:
@@ -893,7 +894,7 @@ class Int64Type(IntegralType):
 
     _range = [-9223372036854775808, 9223372036854775807]
 
-    def from_raw(self, raw: RawScalar) -> Optional[int]:
+    def from_raw(self: Int64Type, raw: RawScalar) -> Optional[int]:
         """Override superclass method.
 
         According to [RFC7951]_, a raw instance must be string.
@@ -905,7 +906,7 @@ class Int64Type(IntegralType):
         except (ValueError, TypeError):
             return None
 
-    def from_xml(self, xml: ET.Element) -> Optional[int]:
+    def from_xml(self: Int64Type, xml: ET.Element) -> Optional[int]:
         """Override superclass method.
 
         XML is always delivered as a text element
@@ -915,10 +916,10 @@ class Int64Type(IntegralType):
         except (ValueError, TypeError):
             return None
 
-    def to_raw(self, val: int) -> str:
+    def to_raw(self: Int64Type, val: int) -> str:
         return self.canonical_string(val)
 
-    def to_xml(self, val: int) -> str:
+    def to_xml(self: Int64Type, val: int) -> str:
         return self.canonical_string(val)
 
 
@@ -945,7 +946,7 @@ class Uint64Type(IntegralType):
 
     _range = [0, 18446744073709551615]
 
-    def from_raw(self, raw: str) -> Optional[int]:
+    def from_raw(self: Uint64Type, raw: str) -> Optional[int]:
         """Override superclass method.
 
         According to [RFC7951]_, a raw instance must be string.
@@ -957,7 +958,7 @@ class Uint64Type(IntegralType):
         except (ValueError, TypeError):
             return None
 
-    def from_xml(self, xml: ET.Element) -> Optional[int]:
+    def from_xml(self: Uint64Type, xml: ET.Element) -> Optional[int]:
         """Override superclass method.
 
         XML is always delivered as a text element
@@ -967,59 +968,59 @@ class Uint64Type(IntegralType):
         except (ValueError, TypeError):
             return None
 
-    def to_raw(self, val: int) -> str:
+    def to_raw(self: Uint64Type, val: int) -> str:
         return self.canonical_string(val)
 
-    def to_xml(self, val: int) -> str:
+    def to_xml(self: Uint64Type, val: int) -> str:
         return self.canonical_string(val)
 
 
 class UnionType(DataType):
     """Class representing YANG "union" type."""
 
-    def __init__(self, sctx: SchemaContext, name: YangIdentifier):
+    def __init__(self: UnionType, sctx: SchemaContext, name: YangIdentifier):
         """Initialize the class instance."""
         super().__init__(sctx, name)
         self.types = []  # type: List[DataType]
 
-    def to_raw(self, val: ScalarValue) -> RawScalar:
+    def to_raw(self: UnionType, val: ScalarValue) -> RawScalar:
         for t in self.types:
             if val in t:
                 return t.to_raw(val)
 
-    def to_xml(self, val: ScalarValue) -> RawScalar:
+    def to_xml(self: UnionType, val: ScalarValue) -> RawScalar:
         for t in self.types:
             if val in t:
                 return t.to_xml(val)
 
-    def canonical_string(self, val: ScalarValue) -> Optional[str]:
+    def canonical_string(self: UnionType, val: ScalarValue) -> Optional[str]:
         for t in self.types:
             if val in t:
                 return t.canonical_string(val)
         return None
 
-    def parse_value(self, text: str) -> Optional[ScalarValue]:
+    def parse_value(self: UnionType, text: str) -> Optional[ScalarValue]:
         for t in self.types:
             val = t.parse_value(text)
             if val is not None and val in t:
                 return val
         return None
 
-    def from_raw(self, raw: RawScalar) -> Optional[ScalarValue]:
+    def from_raw(self: UnionType, raw: RawScalar) -> Optional[ScalarValue]:
         for t in self.types:
             val = t.from_raw(raw)
             if val is not None and val in t:
                 return val
         return None
 
-    def from_xml(self, xml: ET.Element) -> Optional[ScalarValue]:
+    def from_xml(self: UnionType, xml: ET.Element) -> Optional[ScalarValue]:
         for t in self.types:
             val = t.from_xml(xml)
             if val is not None and val in t:
                 return val
         return None
 
-    def __contains__(self, val: Any) -> bool:
+    def __contains__(self: UnionType, val: Any) -> bool:
         for t in self.types:
             try:
                 if val in t:
@@ -1028,11 +1029,11 @@ class UnionType(DataType):
                 continue
         return False
 
-    def _handle_properties(self, stmt: Statement, sctx: SchemaContext) -> None:
+    def _handle_properties(self: UnionType, stmt: Statement, sctx: SchemaContext) -> None:
         self.types = [self._resolve_type(ts, sctx)
                       for ts in stmt.find_all("type")]
 
-    def _post_process(self, tnode: "TerminalNode") -> None:
+    def _post_process(self: UnionType, tnode: "TerminalNode") -> None:
         for t in self.types:
             t._post_process(tnode)
 

--- a/yangson/enumerations.py
+++ b/yangson/enumerations.py
@@ -16,6 +16,7 @@
 # with Yangson.  If not, see <http://www.gnu.org/licenses/>.
 
 """Enumeration classes."""
+from __future__ import annotations
 
 from enum import Enum
 
@@ -77,7 +78,7 @@ class Axis(Enum):
     self = 10
     """Just the context node."""
 
-    def __str__(self) -> str:
+    def __str__(self: Axis) -> str:
         """Return string representation of the axis."""
         return self.name.replace("_", "-")
 
@@ -92,6 +93,6 @@ class MultiplicativeOp(Enum):
     modulo = "mod"
     """Modulo operator (``mod``)."""
 
-    def __str__(self) -> str:
+    def __str__(self: MultiplicativeOp) -> str:
         """Return string representation of the operation."""
         return self.value

--- a/yangson/exceptions.py
+++ b/yangson/exceptions.py
@@ -68,6 +68,7 @@ This module defines the following exceptions:
 * :exc:`YangsonException`: Base class for all Yangson exceptions.
 * :exc:`YangTypeError`: A scalar value is of incorrect type.
 """
+from __future__ import annotations
 
 from .typealiases import (InstanceName, JSONPointer, ModuleId, PrefName,
                           QualName, ScalarValue, YangIdentifier)
@@ -81,72 +82,72 @@ class YangsonException(Exception):
 class AnnotationException(YangsonException):
     """Abstract class for exceptions related to metadata annotations."""
 
-    def __init__(self, path: JSONPointer):
+    def __init__(self: AnnotationException, path: JSONPointer):
         self.path = path
 
 
 class MissingAnnotationTarget(AnnotationException):
     """Instance node that is being annotated doesn't exist."""
 
-    def __init__(self, path: JSONPointer, iname: InstanceName):
+    def __init__(self: MissingAnnotationTarget, path: JSONPointer, iname: InstanceName):
         super().__init__(path)
         self.iname = iname
 
-    def __str__(self):
+    def __str__(self: MissingAnnotationTarget):
         return f"[{self.path}] no instance '{self.iname}'"
 
 
 class UndefinedAnnotation(AnnotationException):
     """Undefined annotation is used."""
 
-    def __init__(self, path: JSONPointer, aname: InstanceName):
+    def __init__(self: UndefinedAnnotation, path: JSONPointer, aname: InstanceName):
         super().__init__(path)
         self.aname = aname
 
-    def __str__(self):
+    def __str__(self: UndefinedAnnotation):
         return f"[{self.path}] Undefined annotation '{self.aname}'"
 
 
 class AnnotationTypeError(AnnotationException):
     """Type of annotation is incorrect."""
 
-    def __init__(self, path: JSONPointer, aname: InstanceName, msg: str):
+    def __init__(self: AnnotationTypeError, path: JSONPointer, aname: InstanceName, msg: str):
         super().__init__(path)
         self.aname = aname
         self.msg = msg
 
-    def __str__(self):
+    def __str__(self: AnnotationTypeError):
         return f"[{self.path}] value of '{self.aname}' {self.msg}"
 
 
 class InvalidArgument(YangsonException):
     """The argument of a statement is invalid."""
 
-    def __init__(self, arg: str):
+    def __init__(self: InvalidArgument, arg: str):
         self.argument = arg
 
-    def __str__(self):
+    def __str__(self: InvalidArgument):
         return self.argument
 
 
 class InvalidKeyValue(YangsonException):
     """List key or leaf-list value is invalid."""
 
-    def __init__(self, value: ScalarValue):
+    def __init__(self: InvalidKeyValue, value: ScalarValue):
         self.value = value
 
-    def __str__(self):
+    def __str__(self: InvalidKeyValue):
         return str(self.value)
 
 
 class InstanceException(YangsonException):
     """Abstract class for exceptions related to operations on instance nodes."""
 
-    def __init__(self, path: JSONPointer, message: str):
+    def __init__(self: InstanceException, path: JSONPointer, message: str):
         self.path = path
         self.message = message
 
-    def __str__(self):
+    def __str__(self: InstanceException):
         return f"[{self.path}] {self.message}"
 
 
@@ -168,10 +169,10 @@ class NonDataNode(InstanceException):
 class ParserException(YangsonException):
     """Base class for parser exceptions."""
 
-    def __init__(self, parser: "Parser"):
+    def __init__(self: ParserException, parser: "Parser"):
         self.parser = parser
 
-    def __str__(self) -> str:
+    def __str__(self: ParserException) -> str:
         """Print parser state."""
         if "\n" in self.parser.input:
             (line, col) = self.parser.line_column()
@@ -187,11 +188,11 @@ class EndOfInput(ParserException):
 class UnexpectedInput(ParserException):
     """Unexpected input."""
 
-    def __init__(self, parser: "Parser", expected: str = None):
+    def __init__(self: UnexpectedInput, parser: "Parser", expected: str = None):
         super().__init__(parser)
         self.expected = expected
 
-    def __str__(self) -> str:
+    def __str__(self: UnexpectedInput) -> str:
         """Add info about expected input if available."""
         ex = "" if self.expected is None else ": expected " + self.expected
         return super().__str__() + ex
@@ -210,22 +211,22 @@ class InvalidXPath(ParserException):
 class NotSupported(ParserException):
     """Exception to be raised for unimplemented XPath features."""
 
-    def __init__(self, parser: "Parser", feature: str):
+    def __init__(self: NotSupported, parser: "Parser", feature: str):
         super().__init__(parser)
         self.feature = feature
 
-    def __str__(self) -> str:
+    def __str__(self: NotSupported) -> str:
         return super().str() + ": " + str(self.feature)
 
 
 class MissingModule(YangsonException):
     """Abstract exception class – a module is missing."""
 
-    def __init__(self, name: YangIdentifier, rev: str = ""):
+    def __init__(self: MissingModule, name: YangIdentifier, rev: str = ""):
         self.name = name
         self.rev = rev
 
-    def __str__(self) -> str:
+    def __str__(self: MissingModule) -> str:
         if self.rev:
             return self.name + "@" + self.rev
         return self.name
@@ -234,21 +235,21 @@ class MissingModule(YangsonException):
 class MissingModuleNamespace(YangsonException):
     """Abstract exception class – a module is missing."""
 
-    def __init__(self, ns: str):
+    def __init__(self: MissingModuleNamespace, ns: str):
         self.ns = ns
 
-    def __str__(self) -> str:
+    def __str__(self: MissingModuleNamespace) -> str:
         return self.ns
 
 
 class ModuleContentMismatch(YangsonException):
     """Abstract exception class – unexpected module name or revision."""
 
-    def __init__(self, found: YangIdentifier, expected: YangIdentifier):
+    def __init__(self: ModuleContentMismatch, found: YangIdentifier, expected: YangIdentifier):
         self.found = found
         self.expected = expected
 
-    def __str__(self) -> str:
+    def __str__(self: ModuleContentMismatch) -> str:
         return f"'{self.found}', expected '{self.expected}'"
 
 
@@ -280,20 +281,20 @@ class ModuleNotImplemented(MissingModule):
 class BadYangLibraryData(YangsonException):
     """Broken YANG library data."""
 
-    def __init__(self, message: str):
+    def __init__(self: BadYangLibraryData, message: str):
         self.message = message
 
-    def __str__(self) -> str:
+    def __str__(self: BadYangLibraryData) -> str:
         return self.message
 
 
 class InvalidSchemaPath(YangsonException):
     """Invalid schema or data path."""
 
-    def __init__(self, path: str):
+    def __init__(self: InvalidSchemaPath, path: str):
         self.path = path
 
-    def __str__(self) -> str:
+    def __str__(self: InvalidSchemaPath) -> str:
         return self.path
 
 
@@ -308,53 +309,53 @@ class MissingAugmentTarget(YangsonException):
       ``import``.
     """
 
-    def __init__(self, sni: str):
+    def __init__(self: MissingAugmentTarget, sni: str):
         self.sni = sni
 
-    def __str__(self) -> str:
+    def __str__(self: MissingAugmentTarget) -> str:
         return self.sni
 
 
 class UnknownPrefix(YangsonException):
     """Unknown namespace prefix."""
 
-    def __init__(self, prefix: YangIdentifier, mid: ModuleId):
+    def __init__(self: UnknownPrefix, prefix: YangIdentifier, mid: ModuleId):
         self.prefix = prefix
         self.mid = mid
 
-    def __str__(self) -> str:
+    def __str__(self: UnknownPrefix) -> str:
         return f"prefix {self.prefix} is not defined in {self.mid}"
 
 
 class ModuleNotImported(YangsonException):
     """Module is not imported."""
 
-    def __init__(self, mod: YangIdentifier, mid: ModuleId):
+    def __init__(self: ModuleNotImported, mod: YangIdentifier, mid: ModuleId):
         self.mod = mod
         self.mid = mid
 
-    def __str__(self) -> str:
+    def __str__(self: ModuleNotImported) -> str:
         return f"{self.mod} not imported in {self.mid}"
 
 
 class FeaturePrerequisiteError(YangsonException):
     """Pre-requisite feature is not supported."""
 
-    def __init__(self, name: YangIdentifier, ns: YangIdentifier):
+    def __init__(self: FeaturePrerequisiteError, name: YangIdentifier, ns: YangIdentifier):
         self.name = name
         self.ns = ns
 
-    def __str__(self) -> str:
+    def __str__(self: FeaturePrerequisiteError) -> str:
         return f"{self.ns}:{self.name}"
 
 
 class MultipleImplementedRevisions(YangsonException):
     """A module has multiple implemented revisions."""
 
-    def __init__(self, module: YangIdentifier):
+    def __init__(self: MultipleImplementedRevisions, module: YangIdentifier):
         self.module = module
 
-    def __str__(self) -> str:
+    def __str__(self: MultipleImplementedRevisions) -> str:
         return self.module
 
 
@@ -366,23 +367,23 @@ class CyclicImports(YangsonException):
 class SchemaNodeException(YangsonException):
     """Abstract exception class for schema node errors."""
 
-    def __init__(self, qn: QualName):
+    def __init__(self: SchemaNodeException, qn: QualName):
         self.qn = qn
 
-    def __str__(self) -> str:
+    def __str__(self: SchemaNodeException) -> str:
         return "/" if self.qn[0] is None else f"{self.qn[1]}:{self.qn[0]}"
 
 
 class NonexistentSchemaNode(SchemaNodeException):
     """A schema node doesn't exist."""
 
-    def __init__(self, qn: QualName, name: YangIdentifier,
+    def __init__(self: NonexistentSchemaNode, qn: QualName, name: YangIdentifier,
                  ns: YangIdentifier = None):
         super().__init__(qn)
         self.name = name
         self.ns = ns
 
-    def __str__(self) -> str:
+    def __str__(self: NonexistentSchemaNode) -> str:
         prefix = "" if self.ns is None or self.ns == self.qn[1] else self.ns + ":"
         return f"{prefix}{self.name} under {super().__str__()}"
 
@@ -390,11 +391,11 @@ class NonexistentSchemaNode(SchemaNodeException):
 class BadSchemaNodeType(SchemaNodeException):
     """A schema node is of a wrong type."""
 
-    def __init__(self, qn: QualName, expected: str):
+    def __init__(self: BadSchemaNodeType, qn: QualName, expected: str):
         super().__init__(qn)
         self.expected = expected
 
-    def __str__(self) -> str:
+    def __str__(self: BadSchemaNodeType) -> str:
         return super().__str__() + " is not a " + self.expected
 
 
@@ -406,10 +407,10 @@ class InvalidLeafrefPath(SchemaNodeException):
 class RawDataError(YangsonException):
     """Abstract exception class for errors in raw data."""
 
-    def __init__(self, path: JSONPointer):
+    def __init__(self: RawDataError, path: JSONPointer):
         self.path = path
 
-    def __str__(self) -> JSONPointer:
+    def __str__(self: RawDataError) -> JSONPointer:
         return self.path
 
 
@@ -421,23 +422,23 @@ class RawMemberError(RawDataError):
 class RawTypeError(RawDataError):
     """Raw value is of an incorrect type."""
 
-    def __init__(self, path: JSONPointer, expected: str):
+    def __init__(self: RawTypeError, path: JSONPointer, expected: str):
         super().__init__(path)
         self.message = "expected " + expected
 
-    def __str__(self):
+    def __str__(self: RawTypeError):
         return f"[{self.path}] {self.message}"
 
 
 class ValidationError(YangsonException):
     """Abstract exception class for instance validation errors."""
 
-    def __init__(self, path: JSONPointer, tag: str, message: str = None):
+    def __init__(self: ValidationError, path: JSONPointer, tag: str, message: str = None):
         self.path = path
         self.tag = tag
         self.message = message
 
-    def __str__(self) -> str:
+    def __str__(self: ValidationError) -> str:
         msg = ": " + self.message if self.message else ""
         return f"[{self.path}] {self.tag}{msg}"
 
@@ -460,11 +461,11 @@ class YangTypeError(ValidationError):
 class StatementNotFound(YangsonException):
     """Required statement does not exist."""
 
-    def __init__(self, parent: PrefName, kw: YangIdentifier):
+    def __init__(self: StatementNotFound, parent: PrefName, kw: YangIdentifier):
         self.parent = parent
         self.keyword = kw
 
-    def __str__(self) -> str:
+    def __str__(self: StatementNotFound) -> str:
         """Print the statement's keyword."""
         return f"`{self.keyword}' in `{self.parent}'"
 
@@ -472,21 +473,21 @@ class StatementNotFound(YangsonException):
 class DefinitionNotFound(YangsonException):
     """Requested definition does not exist."""
 
-    def __init__(self, kw: YangIdentifier, name: YangIdentifier):
+    def __init__(self: DefinitionNotFound, kw: YangIdentifier, name: YangIdentifier):
         self.keyword = kw
         self.name = name
 
-    def __str__(self) -> str:
+    def __str__(self: DefinitionNotFound) -> str:
         return f"{self.keyword} {self.name}"
 
 
 class XPathTypeError(YangsonException):
     """The value of an XPath (sub)expression is of a wrong type."""
 
-    def __init__(self, value: str):
+    def __init__(self: XPathTypeError, value: str):
         self.value = value
 
-    def __str__(self) -> str:
+    def __str__(self: XPathTypeError) -> str:
         return self.value
 
 

--- a/yangson/instance.py
+++ b/yangson/instance.py
@@ -28,6 +28,7 @@ This module implements the following classes:
 * ResourceIdParser: Parser for RESTCONF resource identifiers.
 * InstanceIdParser: Parser for instance identifiers.
 """
+from __future__ import annotations
 
 from datetime import datetime
 import json
@@ -52,16 +53,16 @@ __all__ = ["InstanceNode", "RootNode", "ObjectMember", "ArrayEntry",
 
 
 class OutputFilter:
-    def begin_member(self, parent: "InstanceNode", node: "InstanceNode", attributes: dict)->bool:
+    def begin_member(self: OutputFilter, parent: "InstanceNode", node: "InstanceNode", attributes: dict)->bool:
         return True
 
-    def end_member(self, parent: "InstanceNode", node: "InstanceNode", attributes: dict)->bool:
+    def end_member(self: OutputFilter, parent: "InstanceNode", node: "InstanceNode", attributes: dict)->bool:
         return True
 
-    def begin_element(self, parent: "InstanceNode", node: "InstanceNode", attributes: dict)->bool:
+    def begin_element(self: OutputFilter, parent: "InstanceNode", node: "InstanceNode", attributes: dict)->bool:
         return True
 
-    def end_element(self, parent: "InstanceNode", node: "InstanceNode", attributes: dict)->bool:
+    def end_element(self: OutputFilter, parent: "InstanceNode", node: "InstanceNode", attributes: dict)->bool:
         return True
 
 
@@ -80,18 +81,18 @@ class LinkedList:
             res = cls(v, res)
         return res
 
-    def __init__(self, head: Value, tail: "LinkedList"):
+    def __init__(self: LinkedList, head: Value, tail: "LinkedList"):
         """Initialize the class instance."""
         self.head = head
         """Head of the linked list."""
         self.tail = tail
         """Tail of the linked list."""
 
-    def __bool__(self):
+    def __bool__(self: LinkedList):
         """Return receiver's boolean value."""
         return True
 
-    def __iter__(self):
+    def __iter__(self: LinkedList):
         """Iterate over receiver's entries."""
         cdr = self
         while True:
@@ -101,7 +102,7 @@ class LinkedList:
                 return
             yield n
 
-    def cons(self, val: Value) -> "LinkedList":
+    def cons(self: LinkedList, val: Value) -> "LinkedList":
         """Prepend a value to the receiver in the persistent way.
 
         Args:
@@ -111,7 +112,7 @@ class LinkedList:
         """
         return LinkedList(val, self)
 
-    def pop(self) -> Tuple[Value, "LinkedList"]:
+    def pop(self: LinkedList) -> Tuple[Value, "LinkedList"]:
         """Deconstruct the receiver.
 
         Returns: A tuple with receiver's head and tail, respectively.
@@ -122,16 +123,16 @@ class LinkedList:
 class EmptyList(LinkedList, metaclass=_Singleton):
     """Singleton class representing the empty linked list."""
 
-    def __init__(self):
+    def __init__(self: EmptyList):
         pass
 
-    def __bool__(self):
+    def __bool__(self: EmptyList):
         return False
 
-    def __getitem__(self, key):
+    def __getitem__(self: EmptyList, key):
         raise IndexError
 
-    def pop(self) -> None:
+    def pop(self: EmptyList) -> None:
         raise IndexError
 
 
@@ -139,7 +140,7 @@ class InstanceNode:
     """YANG data node instance implemented as a zipper structure."""
     _key: InstanceKey
 
-    def __init__(self, key: InstanceKey, value: Value,
+    def __init__(self: InstanceNode, key: InstanceKey, value: Value,
                  parinst: Optional["InstanceNode"],
                  schema_node: "DataNode", timestamp: datetime):
         """Initialize the class instance."""
@@ -156,17 +157,17 @@ class InstanceNode:
         """Value of the receiver."""
 
     @property
-    def name(self) -> InstanceName:
+    def name(self: InstanceNode) -> InstanceName:
         """Name of the receiver."""
         return self._key
 
     @property
-    def namespace(self) -> Optional[YangIdentifier]:
+    def namespace(self: InstanceNode) -> Optional[YangIdentifier]:
         """The receiver's namespace."""
         return self.schema_node.ns
 
     @property
-    def path(self) -> Tuple[InstanceKey]:
+    def path(self: InstanceNode) -> Tuple[InstanceKey]:
         """Return the list of keys on the path from root to the receiver."""
         res = []
         inst: InstanceNode = self
@@ -175,13 +176,13 @@ class InstanceNode:
             inst = inst.parinst
         return tuple(res)
 
-    def __str__(self) -> str:
+    def __str__(self: InstanceNode) -> str:
         """Return string representation of the receiver's value."""
         sn = self.schema_node
         return (str(self.value) if isinstance(self.value, StructuredValue) else
                 sn.type.canonical_string(self.value))
 
-    def json_pointer(self, expand_keys=False) -> JSONPointer:
+    def json_pointer(self: InstanceNode, expand_keys=False) -> JSONPointer:
         """Return JSON Pointer [RFC6901]_ of the receiver."""
         if not expand_keys:
             return "/" + "/".join(str(c) for c in self.path)
@@ -200,7 +201,7 @@ class InstanceNode:
             inst = inst.parinst
         return "/" + "/".join(str(c) for c in res)
 
-    def __getitem__(self, key: InstanceKey) -> "InstanceNode":
+    def __getitem__(self: InstanceNode, key: InstanceKey) -> "InstanceNode":
         """Return member or entry with the given key.
 
         Args:
@@ -217,7 +218,7 @@ class InstanceNode:
             return self._entry(key)
         raise InstanceValueError(self.json_pointer(), "scalar instance")
 
-    def __iter__(self):
+    def __iter__(self: InstanceNode):
         """Return receiver's iterator.
 
         Raises:
@@ -239,12 +240,12 @@ class InstanceNode:
         raise InstanceValueError(self.json_pointer(),
             "{} is a scalar instance".format(str(type(self.value))))
 
-    def is_internal(self) -> bool:
+    def is_internal(self: InstanceNode) -> bool:
         """Return ``True`` if the receiver is an instance of an internal node.
         """
         return isinstance(self.schema_node, InternalNode)
 
-    def put_member(self, name: InstanceName, value: Value,
+    def put_member(self: InstanceNode, name: InstanceName, value: Value,
                    raw: bool = False) -> "InstanceNode":
         """Return receiver's member with a new value.
 
@@ -268,7 +269,7 @@ class InstanceNode:
         newval[name] = csn.from_raw(value, self.json_pointer()) if raw else value
         return self._copy(newval)._member(name)
 
-    def delete_item(self, key: InstanceKey) -> "InstanceNode":
+    def delete_item(self: InstanceNode, key: InstanceKey) -> "InstanceNode":
         """Delete an item (member or entry) from receiver's value.
 
         Args:
@@ -288,7 +289,7 @@ class InstanceNode:
                                       f"item '{key}'") from None
         return self._copy(newval)
 
-    def up(self) -> "InstanceNode":
+    def up(self: InstanceNode) -> "InstanceNode":
         """Return an instance node corresponding to the receiver's parent.
 
         Raises:
@@ -297,14 +298,14 @@ class InstanceNode:
         ts = max(self.timestamp, self.parinst.timestamp)
         return self.parinst._copy(self._zip(), ts)
 
-    def top(self) -> "InstanceNode":
+    def top(self: InstanceNode) -> "InstanceNode":
         """Return an instance node corresponding to the root of the data tree."""
         inst = self
         while inst.parinst:
             inst = inst.up()
         return inst
 
-    def update(self, value: Union[RawValue, Value],
+    def update(self: InstanceNode, value: Union[RawValue, Value],
                raw: bool = False) -> "InstanceNode":
         """Update the receiver's value.
 
@@ -319,7 +320,7 @@ class InstanceNode:
             value, self.json_pointer()) if raw else value
         return self._copy(newval)
 
-    def goto(self, iroute: "InstanceRoute") -> "InstanceNode":
+    def goto(self: InstanceNode, iroute: "InstanceRoute") -> "InstanceNode":
         """Move the focus to an instance inside the receiver's value.
 
         Args:
@@ -340,7 +341,7 @@ class InstanceNode:
             inst = sel.goto_step(inst)
         return inst
 
-    def peek(self, iroute: "InstanceRoute") -> Optional[Value]:
+    def peek(self: InstanceNode, iroute: "InstanceRoute") -> Optional[Value]:
         """Return a value within the receiver's subtree.
 
         Args:
@@ -354,7 +355,7 @@ class InstanceNode:
                 return None
         return val
 
-    def validate(self, scope: ValidationScope = ValidationScope.all,
+    def validate(self: InstanceNode, scope: ValidationScope = ValidationScope.all,
                  ctype: ContentType = ContentType.config) -> None:
         """Validate the receiver's value.
 
@@ -369,7 +370,7 @@ class InstanceNode:
         """
         self.schema_node._validate(self, scope, ctype)
 
-    def add_defaults(self, ctype: ContentType = None, tag: bool = False) -> "InstanceNode":
+    def add_defaults(self: InstanceNode, ctype: ContentType = None, tag: bool = False) -> "InstanceNode":
         """Return the receiver with defaults added recursively to its value.
 
         Args:
@@ -402,7 +403,7 @@ class InstanceNode:
                 break
         return res.up()
 
-    def _mark_defaults(self, objvalue):
+    def _mark_defaults(self: InstanceNode, objvalue):
         """Mark all values set in parameter but not in our own value as
         default with the relevant metadata attribute
 
@@ -422,7 +423,7 @@ class InstanceNode:
                     metadata['ietf-netconf-with-defaults:default'] = True
                     objvalue['@'+key] = metadata
 
-    def _get_attributes(self) -> dict:
+    def _get_attributes(self: InstanceNode) -> dict:
         # collect attributes
         attr = {}
         for m in self.value:
@@ -436,7 +437,7 @@ class InstanceNode:
                 attr[m[1:]] = self.value[m]
         return attr
 
-    def raw_value(self, filter: OutputFilter = OutputFilter()) -> RawValue:
+    def raw_value(self: InstanceNode, filter: OutputFilter = OutputFilter()) -> RawValue:
         """Return receiver's value in a raw form (ready for JSON encoding)."""
         if isinstance(self.schema_node, AnyContentNode):
             return self.schema_node.to_raw(self.value)
@@ -479,7 +480,7 @@ class InstanceNode:
             return value
         return self.schema_node.type.to_raw(self.value)
 
-    def to_xml(self, filter: OutputFilter = OutputFilter(), elem: ET.Element = None):
+    def to_xml(self: InstanceNode, filter: OutputFilter = OutputFilter(), elem: ET.Element = None):
         """put receiver's value into a XML element"""
         has_default_ns = False
 
@@ -560,11 +561,11 @@ class InstanceNode:
                 element.attrib['xmlns:wd'] = 'urn:ietf:params:xml:ns:netconf:default:1.0'
             return element
 
-    def _member_names(self) -> List[InstanceName]:
+    def _member_names(self: InstanceNode) -> List[InstanceName]:
         if isinstance(self.value, ObjectValue):
             return [m for m in self.value if not m.startswith("@")]
 
-    def _member(self, name: InstanceName) -> "ObjectMember":
+    def _member(self: InstanceNode, name: InstanceName) -> "ObjectMember":
         pts = name.partition(":")
         if pts[1] and pts[0] == self.namespace:
             name = pts[2]
@@ -577,7 +578,7 @@ class InstanceNode:
             raise NonexistentInstance(self.json_pointer(),
                                       f"member '{name}'") from None
 
-    def _entry(self, index: int) -> "ArrayEntry":
+    def _entry(self: InstanceNode, index: int) -> "ArrayEntry":
         val = self.value
         try:
             i = len(val) + index if index < 0 else index
@@ -588,7 +589,7 @@ class InstanceNode:
         except (IndexError, TypeError):
             raise NonexistentInstance(self.json_pointer(), "entry " + str(index)) from None
 
-    def _peek_schema_route(self, sroute: SchemaRoute) -> Value:
+    def _peek_schema_route(self: InstanceNode, sroute: SchemaRoute) -> Value:
         irt = InstanceRoute()
         sn = self.schema_node
         for qn in sroute:
@@ -599,18 +600,18 @@ class InstanceNode:
                 irt.append(MemberName(sn.name, sn.ns))
         return self.peek(irt)
 
-    def _member_schema_node(self, name: InstanceName) -> "DataNode":
+    def _member_schema_node(self: InstanceNode, name: InstanceName) -> "DataNode":
         qname = self.schema_node._iname2qname(name)
         res = self.schema_node.get_data_child(*qname)
         if res is None:
             raise NonexistentSchemaNode(self.schema_node.qual_name, *qname)
         return res
 
-    def _node_set(self) -> List["InstanceNode"]:
+    def _node_set(self: InstanceNode) -> List["InstanceNode"]:
         """XPath - return the list of all receiver's nodes."""
         return list(self) if isinstance(self.value, ArrayValue) else [self]
 
-    def _children(self, qname:
+    def _children(self: InstanceNode, qname:
                   Union[QualName, bool] = None) -> List["InstanceNode"]:
         """XPath - return the list of receiver's children."""
         sn = self.schema_node
@@ -640,7 +641,7 @@ class InstanceNode:
             res.extend(wd._member(mn)._node_set())
         return res
 
-    def _descendants(self, qname: Union[QualName, bool] = None,
+    def _descendants(self: InstanceNode, qname: Union[QualName, bool] = None,
                      with_self: bool = False) -> List["InstanceNode"]:
         """XPath - return the list of receiver's descendants."""
         res = ([] if not with_self or (qname and self.qual_name != qname)
@@ -652,20 +653,20 @@ class InstanceNode:
         return res
 
     def _preceding_siblings(
-            self, qname: Union[QualName, bool] = None) -> List["InstanceNode"]:
+            self: InstanceNode, qname: Union[QualName, bool] = None) -> List["InstanceNode"]:
         """XPath - return the list of receiver's preceding-siblings."""
         return []
 
     def _following_siblings(
-            self, qname: Union[QualName, bool] = None) -> List["InstanceNode"]:
+            self: InstanceNode, qname: Union[QualName, bool] = None) -> List["InstanceNode"]:
         """XPath - return the list of receiver's following-siblings."""
         return []
 
-    def _parent(self) -> List["InstanceNode"]:
+    def _parent(self: InstanceNode) -> List["InstanceNode"]:
         """XPath - return the receiver's parent as a singleton list."""
         return [self.up()]
 
-    def _deref(self) -> List["InstanceNode"]:
+    def _deref(self: InstanceNode) -> List["InstanceNode"]:
         """XPath: return the list of nodes that the receiver refers to."""
         return ([] if self.is_internal() else
                 self.schema_node.type._deref(self))
@@ -674,12 +675,12 @@ class InstanceNode:
 class RootNode(InstanceNode):
     """This class represents the root of the instance tree."""
 
-    def __init__(self, value: Value, schema_node: "DataNode",
+    def __init__(self: RootNode, value: Value, schema_node: "DataNode",
                  schema_data: "SchemaData", timestamp: datetime):
         super().__init__("/", value, None, schema_node, timestamp)
         self.schema_data = schema_data
 
-    def up(self) -> None:
+    def up(self: RootNode) -> None:
         """Override the superclass method.
 
         Raises:
@@ -687,7 +688,7 @@ class RootNode(InstanceNode):
         """
         raise NonexistentInstance(self.json_pointer(), "up of top")
 
-    def to_xml(self, filter: OutputFilter = OutputFilter(),
+    def to_xml(self: RootNode, filter: OutputFilter = OutputFilter(),
                tag: str = "content-data",
                urn: str = "urn:ietf:params:xml:ns:yang:ietf-yang-instance-data"):
         """put receiver's value into a XML element"""
@@ -696,17 +697,17 @@ class RootNode(InstanceNode):
 
         return super().to_xml(filter, element)[0]
 
-    def _copy(self, newval: Value, newts: datetime = None) -> InstanceNode:
+    def _copy(self: RootNode, newval: Value, newts: datetime = None) -> InstanceNode:
         return RootNode(
             newval, self.schema_node, self.schema_data, newts if newts else newval.timestamp)
 
     def _ancestors_or_self(
-            self, qname: Union[QualName, bool] = None) -> List["RootNode"]:
+            self: RootNode, qname: Union[QualName, bool] = None) -> List["RootNode"]:
         """XPath - return the list of receiver's ancestors including itself."""
         return [self] if qname is None else []
 
     def _ancestors(
-            self, qname: Union[QualName, bool] = None) -> List["RootNode"]:
+            self: RootNode, qname: Union[QualName, bool] = None) -> List["RootNode"]:
         """XPath - return the list of receiver's ancestors."""
         return []
 
@@ -714,7 +715,7 @@ class RootNode(InstanceNode):
 class ObjectMember(InstanceNode):
     """This class represents an object member."""
 
-    def __init__(self, key: InstanceName, siblings: Dict[InstanceName, Value],
+    def __init__(self: ObjectMember, key: InstanceName, siblings: Dict[InstanceName, Value],
                  value: Value, parinst: Optional[InstanceNode],
                  schema_node: "DataNode", timestamp: datetime):
         super().__init__(key, value, parinst, schema_node, timestamp)
@@ -722,12 +723,12 @@ class ObjectMember(InstanceNode):
         """Sibling members within the parent object."""
 
     @property
-    def qual_name(self) -> QualName:
+    def qual_name(self: ObjectMember) -> QualName:
         """Return the receiver's qualified name."""
         p, s, loc = self._key.partition(":")
         return (loc, p) if s else (p, self.namespace)
 
-    def sibling(self, name: InstanceName) -> "ObjectMember":
+    def sibling(self: ObjectMember, name: InstanceName) -> "ObjectMember":
         """Return an instance node corresponding to a sibling member.
 
         Args:
@@ -749,7 +750,7 @@ class ObjectMember(InstanceNode):
             raise NonexistentInstance(self.json_pointer(),
                                       f"member '{name}'") from None
 
-    def look_up(self, **keys: Dict[InstanceName, ScalarValue]) -> "ArrayEntry":
+    def look_up(self: ObjectMember, **keys: Dict[InstanceName, ScalarValue]) -> "ArrayEntry":
         """Return the entry with matching keys.
 
         Args:
@@ -777,13 +778,13 @@ class ObjectMember(InstanceNode):
         except TypeError:
             raise InstanceValueError(self.json_pointer(), "lookup on non-list") from None
 
-    def _zip(self) -> ObjectValue:
+    def _zip(self: ObjectMember) -> ObjectValue:
         """Zip the receiver into an object and return it."""
         res = ObjectValue(self.siblings.copy(), self.timestamp)
         res[self.name] = self.value
         return res
 
-    def _copy(self, newval: Value, newts: datetime = None) -> "ObjectMember":
+    def _copy(self: ObjectMember, newval: Value, newts: datetime = None) -> "ObjectMember":
         if newts:
             ts = newts
         elif isinstance(newval, StructuredValue):
@@ -794,13 +795,13 @@ class ObjectMember(InstanceNode):
                             self.schema_node, ts)
 
     def _ancestors_or_self(
-            self, qname: Union[QualName, bool] = None) -> List[InstanceNode]:
+            self: ObjectMember, qname: Union[QualName, bool] = None) -> List[InstanceNode]:
         """XPath - return the list of receiver's ancestors including itself."""
         res = [] if qname and self.qual_name != qname else [self]
         return res + self.up()._ancestors_or_self(qname)
 
     def _ancestors(
-            self, qname: Union[QualName, bool] = None) -> List[InstanceNode]:
+            self: ObjectMember, qname: Union[QualName, bool] = None) -> List[InstanceNode]:
         """XPath - return the list of receiver's ancestors."""
         return self.up()._ancestors_or_self(qname)
 
@@ -808,7 +809,7 @@ class ObjectMember(InstanceNode):
 class ArrayEntry(InstanceNode):
     """This class represents an array entry."""
 
-    def __init__(self, key: int, before: LinkedList, after: LinkedList,
+    def __init__(self: ArrayEntry, key: int, before: LinkedList, after: LinkedList,
                  value: Value, parinst: Optional[InstanceNode],
                  schema_node: "DataNode", timestamp: datetime = None):
         super().__init__(key, value, parinst, schema_node, timestamp)
@@ -818,21 +819,21 @@ class ArrayEntry(InstanceNode):
         """Following entries of the parent array."""
 
     @property
-    def index(self) -> int:
+    def index(self: ArrayEntry) -> int:
         """Index of the receiver in the parent array."""
         return self._key
 
     @property
-    def name(self) -> InstanceName:
+    def name(self: ArrayEntry) -> InstanceName:
         """Name of the receiver."""
         return self.parinst.name
 
     @property
-    def qual_name(self) -> Optional[QualName]:
+    def qual_name(self: ArrayEntry) -> Optional[QualName]:
         """Return the receiver's qualified name."""
         return self.parinst.qual_name
 
-    def update(self, value: Union[RawValue, Value],
+    def update(self: ArrayEntry, value: Union[RawValue, Value],
                raw: bool = False) -> "ArrayEntry":
         """Update the receiver's value.
 
@@ -840,7 +841,7 @@ class ArrayEntry(InstanceNode):
         """
         return super().update(self._cook_value(value, raw), False)
 
-    def previous(self) -> "ArrayEntry":
+    def previous(self: ArrayEntry) -> "ArrayEntry":
         """Return an instance node corresponding to the previous entry.
 
         Raises:
@@ -855,7 +856,7 @@ class ArrayEntry(InstanceNode):
             self.index - 1, nbef, self.after.cons(self.value), newval,
             self.parinst, self.schema_node, self.timestamp)
 
-    def next(self) -> "ArrayEntry":
+    def next(self: ArrayEntry) -> "ArrayEntry":
         """Return an instance node corresponding to the next entry.
 
         Raises:
@@ -869,7 +870,7 @@ class ArrayEntry(InstanceNode):
             self.index + 1, self.before.cons(self.value), naft, newval,
             self.parinst, self.schema_node, self.timestamp)
 
-    def insert_before(self, value: Union[RawValue, Value],
+    def insert_before(self: ArrayEntry, value: Union[RawValue, Value],
                       raw: bool = False) -> "ArrayEntry":
         """Insert a new entry before the receiver.
 
@@ -884,7 +885,7 @@ class ArrayEntry(InstanceNode):
                           self._cook_value(value, raw), self.parinst,
                           self.schema_node, datetime.now())
 
-    def insert_after(self, value: Union[RawValue, Value],
+    def insert_after(self: ArrayEntry, value: Union[RawValue, Value],
                      raw: bool = False) -> "ArrayEntry":
         """Insert a new entry after the receiver.
 
@@ -899,11 +900,11 @@ class ArrayEntry(InstanceNode):
                           self._cook_value(value, raw), self.parinst,
                           self.schema_node, datetime.now())
 
-    def _cook_value(self, value: Union[RawValue, Value], raw: bool) -> Value:
+    def _cook_value(self: ArrayEntry, value: Union[RawValue, Value], raw: bool) -> Value:
         return super(SequenceNode, self.schema_node).from_raw(
             value, self.json_pointer()) if raw else value
 
-    def _zip(self) -> ArrayValue:
+    def _zip(self: ArrayEntry) -> ArrayValue:
         """Zip the receiver into an array and return it."""
         res = list(self.before)
         res.reverse()
@@ -911,7 +912,7 @@ class ArrayEntry(InstanceNode):
         res.extend(list(self.after))
         return ArrayValue(res, self.timestamp)
 
-    def _copy(self, newval: Value, newts: datetime = None) -> "ArrayEntry":
+    def _copy(self: ArrayEntry, newval: Value, newts: datetime = None) -> "ArrayEntry":
         if newts:
             ts = newts
         elif isinstance(newval, StructuredValue):
@@ -922,18 +923,18 @@ class ArrayEntry(InstanceNode):
                           self.parinst, self.schema_node, ts)
 
     def _ancestors_or_self(
-            self, qname: Union[QualName, bool] = None) -> List[InstanceNode]:
+            self: ArrayEntry, qname: Union[QualName, bool] = None) -> List[InstanceNode]:
         """XPath - return the list of receiver's ancestors including itself."""
         res = [] if qname and self.qual_name != qname else [self]
         return res + self.up()._ancestors(qname)
 
     def _ancestors(
-            self, qname: Union[QualName, bool] = None) -> List[InstanceNode]:
+            self: ArrayEntry, qname: Union[QualName, bool] = None) -> List[InstanceNode]:
         """XPath - return the list of receiver's ancestors."""
         return self.up()._ancestors(qname)
 
     def _preceding_siblings(
-            self, qname: Union[QualName, bool] = None) -> List[InstanceNode]:
+            self: ArrayEntry, qname: Union[QualName, bool] = None) -> List[InstanceNode]:
         """XPath - return the list of receiver's preceding siblings."""
         if qname and self.qual_name != qname:
             return []
@@ -945,7 +946,7 @@ class ArrayEntry(InstanceNode):
         return res
 
     def _following_siblings(
-            self, qname: Union[QualName, bool] = None) -> List[InstanceNode]:
+            self: ArrayEntry, qname: Union[QualName, bool] = None) -> List[InstanceNode]:
         """XPath - return the list of receiver's following siblings."""
         if qname and self.qual_name != qname:
             return []
@@ -956,7 +957,7 @@ class ArrayEntry(InstanceNode):
             res.append(en)
         return res
 
-    def _parent(self) -> List["InstanceNode"]:
+    def _parent(self: ArrayEntry) -> List["InstanceNode"]:
         """XPath - return the receiver's parent as a singleton list."""
         return [self.up().up()]
 
@@ -964,11 +965,11 @@ class ArrayEntry(InstanceNode):
 class InstanceRoute(list):
     """This class represents a route into an instance value."""
 
-    def __str__(self) -> str:
+    def __str__(self: InstanceRoute) -> str:
         """Return a string representation of the receiver."""
         return "".join([str(c) for c in self])
 
-    def __hash__(self) -> int:
+    def __hash__(self: InstanceRoute) -> int:
         """Return the hash value of the receiver."""
         return self.__str__().__hash__()
 
@@ -976,7 +977,7 @@ class InstanceRoute(list):
 class MemberName:
     """Selectors of object members."""
 
-    def __init__(self, name: YangIdentifier, ns: Optional[YangIdentifier]):
+    def __init__(self: MemberName, name: YangIdentifier, ns: Optional[YangIdentifier]):
         """Initialize the class instance.
 
         Args:
@@ -986,18 +987,18 @@ class MemberName:
         self.name = name
         self.namespace = ns
 
-    def __eq__(self, other: "MemberName") -> bool:
+    def __eq__(self: MemberName, other: "MemberName") -> bool:
         return self.name == other.name and self.namespace == other.namespace
 
-    def __str__(self) -> str:
+    def __str__(self: MemberName) -> str:
         """Return a string representation of the receiver."""
         return "/" + self.iname()
 
-    def iname(self) -> str:
+    def iname(self: MemberName) -> str:
         """Return instance name corresponding to the receiver."""
         return f"{self.namespace}:{self.name}" if self.namespace else self.name
 
-    def peek_step(self, val: ObjectValue,
+    def peek_step(self: MemberName, val: ObjectValue,
                   sn: "DataNode") -> Tuple[Value, "DataNode"]:
         """Return member value addressed by the receiver + its schema node.
 
@@ -1011,7 +1012,7 @@ class MemberName:
         except (IndexError, KeyError, TypeError):
             return (None, cn)
 
-    def goto_step(self, inst: InstanceNode) -> InstanceNode:
+    def goto_step(self: MemberName, inst: InstanceNode) -> InstanceNode:
         """Return member instance addressed by the receiver.
 
         Args:
@@ -1023,13 +1024,13 @@ class MemberName:
 class ActionName(MemberName):
     """Name of an action (can appear in RESTCONF resource IDs)."""
 
-    def peek_step(self, val: ObjectValue,
+    def peek_step(self: ActionName, val: ObjectValue,
                   sn: "DataNode") -> Tuple[None, "DataNode"]:
         """Fail because there is no action instance."""
         cn = sn.get_child(self.name, self.namespace)
         return (None, cn)
 
-    def goto_step(self, inst: InstanceNode) -> None:
+    def goto_step(self: ActionName, inst: InstanceNode) -> None:
         """Raise an exception because there is no action instance."""
         raise NonDataNode(inst.json_pointer(), "action " + self.iname())
 
@@ -1037,7 +1038,7 @@ class ActionName(MemberName):
 class EntryIndex:
     """Numeric selectors for a list or leaf-list entry."""
 
-    def __init__(self, index: int):
+    def __init__(self: EntryIndex, index: int):
         """Initialize the class instance.
 
         Args:
@@ -1045,14 +1046,14 @@ class EntryIndex:
         """
         self.index = index
 
-    def __eq__(self, other: "EntryIndex") -> bool:
+    def __eq__(self: EntryIndex, other: "EntryIndex") -> bool:
         return self.index == other.index
 
-    def __str__(self) -> str:
+    def __str__(self: EntryIndex) -> str:
         """Return a string representation of the receiver."""
         return f"[{self.index + 1}]"
 
-    def peek_step(self, val: ArrayValue,
+    def peek_step(self: EntryIndex, val: ArrayValue,
                   sn: "DataNode") -> Tuple[Optional[Value], "DataNode"]:
         """Return entry value addressed by the receiver + its schema node.
 
@@ -1065,7 +1066,7 @@ class EntryIndex:
         except (IndexError, KeyError, TypeError):
             return None, sn
 
-    def goto_step(self, inst: InstanceNode) -> InstanceNode:
+    def goto_step(self: EntryIndex, inst: InstanceNode) -> InstanceNode:
         """Return entry instance addressed by the receiver.
 
         Args:
@@ -1077,7 +1078,7 @@ class EntryIndex:
 class EntryValue:
     """Value-based selectors of an array entry."""
 
-    def __init__(self, value: str):
+    def __init__(self: EntryValue, value: str):
         """Initialize the class instance.
 
         Args:
@@ -1085,21 +1086,21 @@ class EntryValue:
         """
         self.value = value
 
-    def __str__(self) -> str:
+    def __str__(self: EntryValue) -> str:
         """Return a string representation of the receiver."""
         return f"[.={json.dumps(self.value)}]"
 
-    def __eq__(self, other: "EntryValue") -> bool:
+    def __eq__(self: EntryValue, other: "EntryValue") -> bool:
         return self.value == other.value
 
-    def parse_value(self, sn: "DataNode") -> ScalarValue:
+    def parse_value(self: EntryValue, sn: "DataNode") -> ScalarValue:
         """Let schema node's type parse the receiver's value."""
         res = sn.type.parse_value(self.value)
         if res is None:
             raise InvalidKeyValue(self.value)
         return res
 
-    def peek_step(self, val: ArrayValue,
+    def peek_step(self: EntryValue, val: ArrayValue,
                   sn: "DataNode") -> Tuple[Value, "DataNode"]:
         """Return entry value addressed by the receiver + its schema node.
 
@@ -1112,7 +1113,7 @@ class EntryValue:
         except ValueError:
             return None, sn
 
-    def goto_step(self, inst: InstanceNode) -> InstanceNode:
+    def goto_step(self: EntryValue, inst: InstanceNode) -> InstanceNode:
         """Return member instance of `inst` addressed by the receiver.
 
         Args:
@@ -1130,7 +1131,7 @@ class EntryKeys:
     """Key-based selectors for a list entry."""
 
     def __init__(
-            self, keys: Dict[Tuple[YangIdentifier, Optional[YangIdentifier]], str]):
+            self: EntryKeys, keys: Dict[Tuple[YangIdentifier, Optional[YangIdentifier]], str]):
         """Initialize the class instance.
 
         Args:
@@ -1138,7 +1139,7 @@ class EntryKeys:
         """
         self.keys = keys
 
-    def __str__(self) -> str:
+    def __str__(self: EntryKeys) -> str:
         """Return a string representation of the receiver."""
         res = []
         for k in self.keys:
@@ -1146,10 +1147,10 @@ class EntryKeys:
             res.append(f"[{kn}={json.dumps(self.keys[k])}]")
         return "".join(res)
 
-    def __eq__(self, other: "EntryKeys") -> bool:
+    def __eq__(self: EntryKeys, other: "EntryKeys") -> bool:
         return self.keys == other.keys
 
-    def parse_keys(self, sn: "DataNode") -> Dict[InstanceName, ScalarValue]:
+    def parse_keys(self: EntryKeys, sn: "DataNode") -> Dict[InstanceName, ScalarValue]:
         """Parse key dictionary in the context of a schema node.
 
         Args:
@@ -1166,7 +1167,7 @@ class EntryKeys:
             res[knod.iname()] = kval
         return res
 
-    def peek_step(self, val: ArrayValue,
+    def peek_step(self: EntryKeys, val: ArrayValue,
                   sn: "DataNode") -> Tuple[ObjectValue, "DataNode"]:
         """Return the entry addressed by the receiver + its schema node.
 
@@ -1188,7 +1189,7 @@ class EntryKeys:
                 return (en, sn)
         return (None, sn)
 
-    def goto_step(self, inst: InstanceNode) -> InstanceNode:
+    def goto_step(self: EntryKeys, inst: InstanceNode) -> InstanceNode:
         """Return member instance of `inst` addressed by the receiver.
 
         Args:
@@ -1200,7 +1201,7 @@ class EntryKeys:
 class ResourceIdParser(Parser):
     """Parser for RESTCONF resource identifiers."""
 
-    def __init__(self, text: str, sn: "DataNode"):
+    def __init__(self: ResourceIdParser, text: str, sn: "DataNode"):
         """Extend the superclass method.
 
         Args:
@@ -1209,7 +1210,7 @@ class ResourceIdParser(Parser):
         super().__init__(text)
         self.schema_node = sn
 
-    def parse(self) -> InstanceRoute:
+    def parse(self: ResourceIdParser) -> InstanceRoute:
         """Parse resource identifier."""
         res = InstanceRoute()
         if self.at_end():
@@ -1241,7 +1242,7 @@ class ResourceIdParser(Parser):
                 self.char("/")
             sn = cn
 
-    def _key_values(self, sn: "SequenceNode") -> Union[EntryKeys, EntryValue]:
+    def _key_values(self: ResourceIdParser, sn: "SequenceNode") -> Union[EntryKeys, EntryValue]:
         """Parse leaf-list value or list keys."""
         try:
             keys = self.up_to("/")
@@ -1268,7 +1269,7 @@ class ResourceIdParser(Parser):
 class InstanceIdParser(Parser):
     """Parser for YANG instance identifiers."""
 
-    def parse(self) -> InstanceRoute:
+    def parse(self: InstanceIdParser) -> InstanceRoute:
         """Parse instance identifier."""
         res = InstanceRoute()
         while True:
@@ -1297,7 +1298,7 @@ class InstanceIdParser(Parser):
                 if self.at_end():
                     return res
 
-    def _get_value(self) -> str:
+    def _get_value(self: InstanceIdParser) -> str:
         self.skip_ws()
         self.char("=")
         self.skip_ws()
@@ -1307,7 +1308,7 @@ class InstanceIdParser(Parser):
         self.char("]")
         return val
 
-    def _key_predicates(self) -> EntryKeys:
+    def _key_predicates(self: InstanceIdParser) -> EntryKeys:
         "Parse one or more key predicates."""
         sel = {}
         while True:

--- a/yangson/instance.py
+++ b/yangson/instance.py
@@ -185,14 +185,16 @@ class InstanceNode:
         """Return JSON Pointer [RFC6901]_ of the receiver."""
         if not expand_keys:
             return "/" + "/".join(str(c) for c in self.path)
-
         res = []
         inst = self
         while inst.parinst:
-            print(type(inst))
             if isinstance(inst, ArrayEntry):
-                keys = [str(inst.value[k[0]]) for k in inst.schema_node.keys]
-                res.insert(0, inst.schema_node.name + '=' + ','.join(keys))
+                if isinstance(inst.schema_node, ListNode):
+                    keys = [str(inst.value[k[0]]) for k in inst.schema_node.keys]
+                    res.insert(0, inst.schema_node.name + '=' + ','.join(keys))
+                else:
+                    res.insert(0, inst.schema_node.name + '=' + inst.value)
+                inst = inst.parinst
             else:
                 res.insert(0, inst.name)
             inst = inst.parinst

--- a/yangson/instvalue.py
+++ b/yangson/instvalue.py
@@ -23,6 +23,7 @@ This module implements the following classes:
 * ArrayValue: Cooked array value of an instance node.
 * ObjectValue: Cooked object value of an instance node.
 """
+from __future__ import annotations
 
 from datetime import datetime
 from typing import Dict, List, Union
@@ -45,7 +46,7 @@ MetadataObject = Dict[PrefName, ScalarValue]
 class StructuredValue:
     """Abstract class for array and object values."""
 
-    def __init__(self, ts: datetime):
+    def __init__(self: StructuredValue, ts: datetime):
         """Initialize class instance.
 
         Args:
@@ -53,15 +54,15 @@ class StructuredValue:
         """
         self.timestamp = ts if ts else datetime.now()
 
-    def copy(self) -> "StructuredValue":
+    def copy(self: StructuredValue) -> "StructuredValue":
         """Return a shallow copy of the receiver."""
         return self.__class__(super().copy(), datetime.now())
 
-    def __setitem__(self, key: InstanceKey, value: Value) -> None:
+    def __setitem__(self: StructuredValue, key: InstanceKey, value: Value) -> None:
         super().__setitem__(key, value)
         self.timestamp = datetime.now()
 
-    def __eq__(self, val: "StructuredValue") -> bool:
+    def __eq__(self: StructuredValue, val: "StructuredValue") -> bool:
         """Return ``True`` if the receiver equal to `val`.
 
         Args:
@@ -69,7 +70,7 @@ class StructuredValue:
         """
         return self.__class__ == val.__class__ and hash(self) == hash(val)
 
-    def __hash__(self) -> int:
+    def __hash__(self: StructuredValue) -> int:
         """Return hash value for the receiver."""
         raise NotImplementedError()
 
@@ -77,11 +78,11 @@ class StructuredValue:
 class ArrayValue(StructuredValue, list):
     """This class represents cooked array values."""
 
-    def __init__(self, val: List[EntryValue] = [], ts: datetime = None):
+    def __init__(self: ArrayValue, val: List[EntryValue] = [], ts: datetime = None):
         StructuredValue.__init__(self, ts)
         list.__init__(self, val)
 
-    def __hash__(self) -> int:
+    def __hash__(self: ArrayValue) -> int:
         """Return hash value for the receiver."""
         return tuple([x.__hash__() for x in self]).__hash__()
 
@@ -89,12 +90,12 @@ class ArrayValue(StructuredValue, list):
 class ObjectValue(StructuredValue, dict):
     """This class represents cooked object values."""
 
-    def __init__(self, val: Dict[InstanceName, Value] = {},
+    def __init__(self: ObjectValue, val: Dict[InstanceName, Value] = {},
                  ts: datetime = None):
         StructuredValue.__init__(self, ts)
         dict.__init__(self, val)
 
-    def __hash__(self) -> int:
+    def __hash__(self: ObjectValue) -> int:
         """Return hash value for the receiver."""
         sks = sorted(self.keys())
         return tuple([(k, self[k].__hash__()) for k in sks]).__hash__()

--- a/yangson/nodeset.py
+++ b/yangson/nodeset.py
@@ -16,6 +16,7 @@
 # with Yangson.  If not, see <http://www.gnu.org/licenses/>.
 
 """XPath node-set"""
+from __future__ import annotations
 
 from typing import Callable, Union
 from numbers import Number
@@ -42,24 +43,24 @@ def comparison(meth):
 
 class NodeSet(list):
 
-    def union(self, ns: "NodeSet") -> "NodeSet":
+    def union(self: NodeSet, ns: "NodeSet") -> "NodeSet":
         paths = set([n.path for n in self])
         return self.__class__(self + [n for n in ns if n.path not in paths])
 
-    def bind(self, trans: NodeExpr) -> "NodeSet":
+    def bind(self: NodeSet, trans: NodeExpr) -> "NodeSet":
         res = self.__class__([])
         for n in self:
             res = res.union(trans(n))
         return res
 
-    def __float__(self) -> float:
+    def __float__(self: NodeSet) -> float:
         return float(self[0].value)
 
-    def __str__(self) -> str:
+    def __str__(self: NodeSet) -> str:
         return str(self[0]) if self else ""
 
     @comparison
-    def __eq__(self, val: XPathValue) -> bool:
+    def __eq__(self: NodeSet, val: XPathValue) -> bool:
         for n in self:
             if n.is_internal():
                 continue
@@ -74,7 +75,7 @@ class NodeSet(list):
         return False
 
     @comparison
-    def __ne__(self, val: XPathValue) -> bool:
+    def __ne__(self: NodeSet, val: XPathValue) -> bool:
         for n in self:
             if n.is_internal():
                 continue
@@ -89,7 +90,7 @@ class NodeSet(list):
         return False
 
     @comparison
-    def __gt__(self, val: XPathValue) -> bool:
+    def __gt__(self: NodeSet, val: XPathValue) -> bool:
         try:
             val = float(val)
         except (ValueError, TypeError):
@@ -103,7 +104,7 @@ class NodeSet(list):
         return False
 
     @comparison
-    def __lt__(self, val: XPathValue) -> bool:
+    def __lt__(self: NodeSet, val: XPathValue) -> bool:
         try:
             val = float(val)
         except (ValueError, TypeError):
@@ -117,7 +118,7 @@ class NodeSet(list):
         return False
 
     @comparison
-    def __ge__(self, val: XPathValue) -> bool:
+    def __ge__(self: NodeSet, val: XPathValue) -> bool:
         try:
             val = float(val)
         except (ValueError, TypeError):
@@ -131,7 +132,7 @@ class NodeSet(list):
         return False
 
     @comparison
-    def __le__(self, val: XPathValue) -> bool:
+    def __le__(self: NodeSet, val: XPathValue) -> bool:
         try:
             val = float(val)
         except (ValueError, TypeError):

--- a/yangson/parser.py
+++ b/yangson/parser.py
@@ -21,6 +21,7 @@ This module implements the following class:
 
 * Parser: Recursive-descent parser.
 """
+from __future__ import annotations
 
 import re
 from typing import Callable, List, Dict, Optional, Tuple
@@ -52,7 +53,7 @@ class Parser:
     ufloat_re = re.compile(fr"{_uint}(\.{_uint})?|\.{_uint}")
     """Regular expression for unsigned float."""
 
-    def __init__(self, text: str):
+    def __init__(self: Parser, text: str):
         """Initialize the class instance.
 
         Args:
@@ -63,24 +64,24 @@ class Parser:
         self.offset = 0  # type: int
         """Current position in the input text."""
 
-    def __str__(self) -> str:
+    def __str__(self: Parser) -> str:
         """Return string representation of the receiver's input text and state."""
         return self.input[:self.offset] + "§" + self.input[self.offset:]
 
-    def adv_skip_ws(self) -> bool:
+    def adv_skip_ws(self: Parser) -> bool:
         """Advance offset and skip optional whitespace."""
         self.offset += 1
         return self.skip_ws()
 
-    def at_end(self) -> bool:
+    def at_end(self: Parser) -> bool:
         """Return ``True`` if at end of input."""
         return self.offset >= len(self.input)
 
-    def at_last_char(self) -> bool:
+    def at_last_char(self: Parser) -> bool:
         """Return ``True`` if at last character of input."""
         return self.offset == (len(self.input) - 1)
 
-    def char(self, c: str) -> None:
+    def char(self: Parser, c: str) -> None:
         """Parse the specified character.
 
         Args:
@@ -95,7 +96,7 @@ class Parser:
         else:
             raise UnexpectedInput(self, f"char '{c}'")
 
-    def dfa(self, ttab: TransitionTable, init: int = 0) -> int:
+    def dfa(self: Parser, ttab: TransitionTable, init: int = 0) -> int:
         """Run a DFA and return the final (negative) state.
 
         Args:
@@ -114,14 +115,14 @@ class Parser:
                 return state
             self.offset += 1
 
-    def line_column(self) -> Tuple[int, int]:
+    def line_column(self: Parser) -> Tuple[int, int]:
         """Return line and column coordinates."""
         ln = self.input.count("\n", 0, self.offset)
         c = (self.offset if ln == 0 else
              self.offset - self.input.rfind("\n", 0, self.offset) - 1)
         return (ln + 1, c)
 
-    def match_regex(self, regex: Pattern, required: bool = False,
+    def match_regex(self: Parser, regex: Pattern, required: bool = False,
                     meaning: str = "") -> str:
         """Parse input based on a regular expression .
 
@@ -140,7 +141,7 @@ class Parser:
         if required:
             raise UnexpectedInput(self, meaning)
 
-    def one_of(self, chset: str) -> str:
+    def one_of(self: Parser, chset: str) -> str:
         """Parse one character form the specified set.
 
         Args:
@@ -158,7 +159,7 @@ class Parser:
             return res
         raise UnexpectedInput(self, "one of " + chset)
 
-    def peek(self) -> str:
+    def peek(self: Parser) -> str:
         """Return the next character without advancing offset.
 
         Raises:
@@ -169,7 +170,7 @@ class Parser:
         except IndexError:
             raise EndOfInput(self)
 
-    def prefixed_name(self) -> Tuple[YangIdentifier, Optional[YangIdentifier]]:
+    def prefixed_name(self: Parser) -> Tuple[YangIdentifier, Optional[YangIdentifier]]:
         """Parse identifier with an optional colon-separated prefix."""
         i1 = self.yang_identifier()
         try:
@@ -181,17 +182,17 @@ class Parser:
         self.offset += 1
         return (self.yang_identifier(), i1)
 
-    def remaining(self) -> str:
+    def remaining(self: Parser) -> str:
         """Return the remaining part of the input string."""
         res = self.input[self.offset:]
         self.offset = len(self.input)
         return res
 
-    def skip_ws(self) -> bool:
+    def skip_ws(self: Parser) -> bool:
         """Skip optional whitespace."""
         return len(self.match_regex(self.ws_re)) > 0
 
-    def test_string(self, string: str) -> bool:
+    def test_string(self: Parser, string: str) -> bool:
         """If `string` comes next, return ``True`` and advance offset.
 
         Args:
@@ -202,15 +203,15 @@ class Parser:
             return True
         return False
 
-    def unsigned_integer(self) -> int:
+    def unsigned_integer(self: Parser) -> int:
         """Parse and return an unsigned integer."""
         return int(self.match_regex(self.uint_re, True, "unsigned integer"))
 
-    def unsigned_float(self) -> float:
+    def unsigned_float(self: Parser) -> float:
         """Parse and return unsigned floating-point number."""
         return float(self.match_regex(self.ufloat_re, True, "unsigned float"))
 
-    def up_to(self, term: str) -> str:
+    def up_to(self: Parser, term: str) -> str:
         """Parse and return segment terminated by the first occurence of a string.
 
         Args:
@@ -226,7 +227,7 @@ class Parser:
         self.offset = end + 1
         return res
 
-    def yang_identifier(self) -> YangIdentifier:
+    def yang_identifier(self: Parser) -> YangIdentifier:
         """Parse and return YANG identifier.
 
         Raises:

--- a/yangson/schemadata.py
+++ b/yangson/schemadata.py
@@ -25,6 +25,7 @@ This module implements the following classes:
 * SchemaData: Repository of YANG schema structures and methods.
 * FeatureExprParser: Parser for if-feature expressions.
 """
+from __future__ import annotations
 
 from typing import Any, Dict, List, MutableSet, Tuple
 from .exceptions import (
@@ -43,7 +44,7 @@ if False:                       # fake import for type aliases
 class IdentityAdjacency:
     """Adjacency data for an identity."""
 
-    def __init__(self):
+    def __init__(self: IdentityAdjacency):
         self.bases = set()  # type: MutableSet[QualName]
         self.derivs = set()  # type: MutableSet[QualName]
 
@@ -51,7 +52,7 @@ class IdentityAdjacency:
 class SchemaContext:
     """Schema data and current schema context."""
 
-    def __init__(self, schema_data: "SchemaData", default_ns: YangIdentifier,
+    def __init__(self: SchemaContext, schema_data: "SchemaData", default_ns: YangIdentifier,
                  text_mid: ModuleId):
         """Initialize the class instance."""
         self.schema_data = schema_data
@@ -64,7 +65,7 @@ class SchemaContext:
 class ModuleData:
     """Data related to a YANG module or submodule."""
 
-    def __init__(self, main_module: YangIdentifier, yang_id: YangIdentifier):
+    def __init__(self: ModuleData, main_module: YangIdentifier, yang_id: YangIdentifier):
         """Initialize the class instance."""
         self.features = set()  # type: MutableSet[YangIdentifier]
         """Set of supported features."""
@@ -93,7 +94,7 @@ class SchemaData:
             mod_path: List of directories to search for YANG modules.
     """
 
-    def __init__(self, yang_lib: Dict[str, Any], mod_path: List[str]) -> None:
+    def __init__(self: SchemaData, yang_lib: Dict[str, Any], mod_path: List[str]) -> None:
         """Initialize the schema structures."""
         self.identity_adjs = {}  # type: Dict[QualName, IdentityAdjacency]
         """Dictionary of identity bases."""
@@ -110,7 +111,7 @@ class SchemaData:
         """List that defines the order of module processing."""
         self._from_yang_library(yang_lib)
 
-    def _from_yang_library(self, yang_lib: Dict[str, Any]) -> None:
+    def _from_yang_library(self: SchemaData, yang_lib: Dict[str, Any]) -> None:
         """Set the schema structures from YANG library data.
 
         Args:
@@ -166,7 +167,7 @@ class SchemaData:
         self._process_imports()
         self._check_feature_dependences()
 
-    def _load_module(self, name: YangIdentifier,
+    def _load_module(self: SchemaData, name: YangIdentifier,
                      rev: RevisionDate, mdata: ModuleData) -> Statement:
         """Read and parse a YANG module or submodule."""
         for d in self.module_search_path:
@@ -186,7 +187,7 @@ class SchemaData:
                 return res
         raise ModuleNotFound(name, rev)
 
-    def _process_imports(self) -> None:
+    def _process_imports(self: SchemaData) -> None:
         impl = set(self.implement.items())
         if len(impl) == 0:
             return
@@ -223,7 +224,7 @@ class SchemaData:
         if [mid for mid in deps if len(deps[mid]) > 0]:
             raise CyclicImports()
 
-    def _check_feature_dependences(self):
+    def _check_feature_dependences(self: SchemaData):
         """Verify feature dependences."""
         for mid in self.modules:
             for fst in self.modules[mid].statement.find_all("feature"):
@@ -233,7 +234,7 @@ class SchemaData:
                 if not self.if_features(fst, mid):
                     raise FeaturePrerequisiteError(fn, fid[0])
 
-    def namespace(self, mid: ModuleId) -> YangIdentifier:
+    def namespace(self: SchemaData, mid: ModuleId) -> YangIdentifier:
         """Return the namespace corresponding to a module or submodule.
 
         Args:
@@ -248,7 +249,7 @@ class SchemaData:
             raise ModuleNotRegistered(*mid) from None
         return mdata.main_module[0]
 
-    def last_revision(self, mod: YangIdentifier) -> ModuleId:
+    def last_revision(self: SchemaData, mod: YangIdentifier) -> ModuleId:
         """Return the last revision of a module that's part of the data model.
 
         Args:
@@ -263,7 +264,7 @@ class SchemaData:
             raise ModuleNotRegistered(mod)
         return sorted(revs, key=lambda x: x[1])[-1]
 
-    def prefix2ns(self, prefix: YangIdentifier, mid: ModuleId) -> YangIdentifier:
+    def prefix2ns(self: SchemaData, prefix: YangIdentifier, mid: ModuleId) -> YangIdentifier:
         """Return the namespace corresponding to a prefix.
 
         Args:
@@ -283,7 +284,7 @@ class SchemaData:
         except KeyError:
             raise UnknownPrefix(prefix, mid) from None
 
-    def resolve_pname(self, pname: PrefName,
+    def resolve_pname(self: SchemaData, pname: PrefName,
                       mid: ModuleId) -> Tuple[YangIdentifier, ModuleId]:
         """Return the name and module identifier in which the name is defined.
 
@@ -305,7 +306,7 @@ class SchemaData:
         except KeyError:
             raise UnknownPrefix(p, mid) from None
 
-    def translate_pname(self, pname: PrefName, mid: ModuleId) -> QualName:
+    def translate_pname(self: SchemaData, pname: PrefName, mid: ModuleId) -> QualName:
         """Translate a prefixed name to a qualified name.
         Args:
             pname: Name with an optional prefix.
@@ -317,7 +318,7 @@ class SchemaData:
         loc, nid = self.resolve_pname(pname, mid)
         return (loc, self.namespace(nid))
 
-    def translate_node_id(self, ni: PrefName, sctx: SchemaContext) -> QualName:
+    def translate_node_id(self: SchemaData, ni: PrefName, sctx: SchemaContext) -> QualName:
         """Translate node identifier to a qualified name.
 
         Args:
@@ -340,7 +341,7 @@ class SchemaData:
         except KeyError:
             raise UnknownPrefix(p, sctx.text_mid) from None
 
-    def prefix(self, imod: YangIdentifier, mid: ModuleId) -> YangIdentifier:
+    def prefix(self: SchemaData, imod: YangIdentifier, mid: ModuleId) -> YangIdentifier:
         """Return the prefix corresponding to an implemented module.
 
         Args:
@@ -365,7 +366,7 @@ class SchemaData:
                 return p
         raise ModuleNotImported(imod, mid)
 
-    def sni2route(self, sni: SchemaNodeId, sctx: SchemaContext) -> SchemaRoute:
+    def sni2route(self: SchemaData, sni: SchemaNodeId, sctx: SchemaContext) -> SchemaRoute:
         """Translate schema node identifier to a schema route.
 
         Args:
@@ -410,7 +411,7 @@ class SchemaData:
                 raise InvalidSchemaPath(path)
         return res
 
-    def get_definition(self, stmt: Statement,
+    def get_definition(self: SchemaData, stmt: Statement,
                        sctx: SchemaContext) -> Tuple[Statement, SchemaContext]:
         """Find the statement defining a grouping or derived type.
 
@@ -451,7 +452,7 @@ class SchemaData:
                     dstmt, SchemaContext(sctx.schema_data, sctx.default_ns, sid))
         raise DefinitionNotFound(kw, stmt.argument)
 
-    def is_derived_from(self, identity: QualName, base: QualName) -> bool:
+    def is_derived_from(self: SchemaData, identity: QualName, base: QualName) -> bool:
         """Return ``True`` if `identity` is derived from `base`."""
         try:
             bases = self.identity_adjs[identity].bases
@@ -464,7 +465,7 @@ class SchemaData:
                 return True
         return False
 
-    def derived_from(self, identity: QualName) -> MutableSet[QualName]:
+    def derived_from(self: SchemaData, identity: QualName) -> MutableSet[QualName]:
         """Return list of identities transitively derived from `identity`."""
         try:
             res = self.identity_adjs[identity].derivs
@@ -474,7 +475,7 @@ class SchemaData:
             res |= self.derived_from(id)
         return res
 
-    def derived_from_all(self, identities: List[QualName]) -> MutableSet[QualName]:
+    def derived_from_all(self: SchemaData, identities: List[QualName]) -> MutableSet[QualName]:
         """Return list of identities transitively derived from all `identity`."""
         if not identities:
             return set()
@@ -483,7 +484,7 @@ class SchemaData:
             res &= self.derived_from(id)
         return res
 
-    def if_features(self, stmt: Statement, mid: ModuleId) -> bool:
+    def if_features(self: SchemaData, stmt: Statement, mid: ModuleId) -> bool:
         """Evaluate ``if-feature`` substatements on a statement, if any.
 
         Args:
@@ -509,7 +510,7 @@ class SchemaData:
 class FeatureExprParser(Parser):
     """Parser and evaluator for if-feature expressions."""
 
-    def __init__(self, text: str, schema_data: SchemaData, mid: ModuleId):
+    def __init__(self: FeatureExprParser, text: str, schema_data: SchemaData, mid: ModuleId):
         """Initialize the parser instance.
 
         Args:
@@ -524,7 +525,7 @@ class FeatureExprParser(Parser):
         self.mid = mid
         self.schema_data = schema_data
 
-    def parse(self) -> bool:
+    def parse(self: FeatureExprParser) -> bool:
         """Parse and evaluate a complete feature expression.
 
         Raises:
@@ -539,7 +540,7 @@ class FeatureExprParser(Parser):
             raise InvalidFeatureExpression(self)
         return res
 
-    def _feature_disj(self) -> bool:
+    def _feature_disj(self: FeatureExprParser) -> bool:
         x = self._feature_conj()
         if self.test_string("or"):
             if not self.skip_ws():
@@ -547,7 +548,7 @@ class FeatureExprParser(Parser):
             return self._feature_disj() or x
         return x
 
-    def _feature_conj(self) -> bool:
+    def _feature_conj(self: FeatureExprParser) -> bool:
         x = self._feature_term()
         if self.test_string("and"):
             if not self.skip_ws():
@@ -555,14 +556,14 @@ class FeatureExprParser(Parser):
             return self._feature_conj() and x
         return x
 
-    def _feature_term(self) -> bool:
+    def _feature_term(self: FeatureExprParser) -> bool:
         if self.test_string("not"):
             if not self.skip_ws():
                 raise InvalidFeatureExpression(self)
             return not self._feature_atom()
         return self._feature_atom()
 
-    def _feature_atom(self) -> bool:
+    def _feature_atom(self: FeatureExprParser) -> bool:
         if self.peek() == "(":
             self.adv_skip_ws()
             res = self._feature_disj()

--- a/yangson/schemanode.py
+++ b/yangson/schemanode.py
@@ -40,6 +40,7 @@ This module implements the following classes:
 * AnydataNode: YANG anydata node.
 * AnyxmlNode: YANG anyxml node.
 """
+from __future__ import annotations
 
 from datetime import datetime
 from itertools import product
@@ -72,7 +73,7 @@ from .xpathparser import XPathParser
 class Annotation:
     """Class for metadata annotations [RFC 7952]."""
 
-    def __init__(self, type: "DataType", description: str = None):
+    def __init__(self: Annotation, type: "DataType", description: str = None):
         """Initialize the class instance."""
         self.type = type
         self.description = description
@@ -81,7 +82,7 @@ class Annotation:
 class SchemaNode:
     """Abstract class for all schema nodes."""
 
-    def __init__(self):
+    def __init__(self: SchemaNode):
         """Initialize the class instance."""
         self.name: Optional[YangIdentifier] = None
         """Name of the receiver."""
@@ -100,32 +101,32 @@ class SchemaNode:
         """Content type of the receiver."""
 
     @property
-    def qual_name(self) -> QualName:
+    def qual_name(self: SchemaNode) -> QualName:
         """Qualified name of the receiver."""
         return (self.name, self.ns)
 
     @property
-    def config(self) -> bool:
+    def config(self: SchemaNode) -> bool:
         """Does the receiver (also) represent configuration?"""
         return self.content_type().value & ContentType.config.value != 0
 
     @property
-    def mandatory(self) -> bool:
+    def mandatory(self: SchemaNode) -> bool:
         """Is the receiver a mandatory node?"""
         return False
 
-    def schema_root(self) -> "SchemaTreeNode":
+    def schema_root(self: SchemaNode) -> "SchemaTreeNode":
         """Return the root node of the receiver's schema."""
         sn = self
         while sn.parent:
             sn = sn.parent
         return sn
 
-    def content_type(self) -> ContentType:
+    def content_type(self: SchemaNode) -> ContentType:
         """Return receiver's content type."""
         return self._ctype if self._ctype else self.parent.content_type()
 
-    def data_parent(self) -> Optional["InternalNode"]:
+    def data_parent(self: SchemaNode) -> Optional["InternalNode"]:
         """Return the closest ancestor data node."""
         parent = self.parent
         while parent:
@@ -133,22 +134,22 @@ class SchemaNode:
                 return parent
             parent = parent.parent
 
-    def iname(self) -> InstanceName:
+    def iname(self: SchemaNode) -> InstanceName:
         """Return the instance name corresponding to the receiver."""
         dp = self.data_parent()
         return (self.name if dp and self.ns == dp.ns
                 else self.ns + ":" + self.name)
 
-    def data_path(self) -> DataPath:
+    def data_path(self: SchemaNode) -> DataPath:
         """Return the receiver's data path."""
         dp = self.data_parent()
         return (dp.data_path() if dp else "") + "/" + self.iname()
 
-    def state_roots(self) -> List[DataPath]:
+    def state_roots(self: SchemaNode) -> List[DataPath]:
         """Return a list of data paths to descendant state data roots."""
         return [r.data_path() for r in self._state_roots()]
 
-    def from_raw(self, rval: RawValue, jptr: JSONPointer = "") -> Value:
+    def from_raw(self: SchemaNode, rval: RawValue, jptr: JSONPointer = "") -> Value:
         """Return instance value transformed from a raw value using receiver.
 
         Args:
@@ -162,7 +163,7 @@ class SchemaNode:
         """
         raise NotImplementedError
 
-    def from_xml(self, rval: ET.Element, jptr: JSONPointer = "", isroot: bool = False) -> Value:
+    def from_xml(self: SchemaNode, rval: ET.Element, jptr: JSONPointer = "", isroot: bool = False) -> Value:
         """Return instance value transformed from a raw value using receiver.
 
         Args:
@@ -176,19 +177,19 @@ class SchemaNode:
         """
         raise NotImplementedError
 
-    def clear_val_counters(self) -> None:
+    def clear_val_counters(self: SchemaNode) -> None:
         """Clear receiver's validation counter."""
         self.val_count = 0
 
-    def _get_description(self, stmt: Statement):
+    def _get_description(self: SchemaNode, stmt: Statement):
         dst = stmt.find1("description")
         if dst is not None:
             self.description = dst.argument
 
-    def _yang_class(self) -> str:
+    def _yang_class(self: SchemaNode) -> str:
         return self.__class__.__name__[:-4].lower()
 
-    def _node_digest(self) -> Dict[str, Any]:
+    def _node_digest(self: SchemaNode) -> Dict[str, Any]:
         """Return dictionary of receiver's properties suitable for clients."""
         res = {"kind": self._yang_class()}
         if self.mandatory:
@@ -197,12 +198,12 @@ class SchemaNode:
             res["description"] = self.description
         return res
 
-    def _tree_name(self) -> str:
+    def _tree_name(self: SchemaNode) -> str:
         """Return the receiver's name to be displayed in ASCII tree."""
         return (self.name if self.parent and self.ns == self.parent.ns
                  else f"{self.ns}:{self.name}")
 
-    def _validate(self, inst: "InstanceNode", scope: ValidationScope,
+    def _validate(self: SchemaNode, inst: "InstanceNode", scope: ValidationScope,
                   ctype: ContentType) -> None:
         """Validate instance against the receiver.
 
@@ -221,16 +222,16 @@ class SchemaNode:
         """
         self.val_count += 1
 
-    def _iname2qname(self, iname: InstanceName) -> QualName:
+    def _iname2qname(self: SchemaNode, iname: InstanceName) -> QualName:
         """Translate instance name to qualified name in the receiver's context.
         """
         p, s, loc = iname.partition(":")
         return (loc, p) if s else (p, self.ns)
 
-    def _flatten(self) -> List["SchemaNode"]:
+    def _flatten(self: SchemaNode) -> List["SchemaNode"]:
         return [self]
 
-    def _handle_substatements(self, stmt: Statement,
+    def _handle_substatements(self: SchemaNode, stmt: Statement,
                               sctx: SchemaContext) -> None:
         """Dispatch actions for substatements of `stmt`."""
         for s in stmt.substatements:
@@ -245,7 +246,7 @@ class SchemaNode:
             method(s, sctx)
 
     def _follow_leafref(
-            self, xpath: "Expr", init: "TerminalNode") -> Optional["DataNode"]:
+            self: SchemaNode, xpath: "Expr", init: "TerminalNode") -> Optional["DataNode"]:
         """Return the data node referred to by a leafref path.
 
         Args:
@@ -271,53 +272,53 @@ class SchemaNode:
             return self.schema_root()
         return None
 
-    def _noop(self, stmt: Statement, sctx: SchemaContext) -> None:
+    def _noop(self: SchemaNode, stmt: Statement, sctx: SchemaContext) -> None:
         pass
 
-    def _config_stmt(self, stmt: Statement, sctx: SchemaContext) -> None:
+    def _config_stmt(self: SchemaNode, stmt: Statement, sctx: SchemaContext) -> None:
         if stmt.argument == "false":
             self._ctype = ContentType.nonconfig
 
-    def _description_stmt(self, stmt: Statement, sctx: SchemaContext) -> None:
+    def _description_stmt(self: SchemaNode, stmt: Statement, sctx: SchemaContext) -> None:
         self.description = stmt.argument
 
-    def _must_stmt(self, stmt: Statement, sctx: SchemaContext) -> None:
+    def _must_stmt(self: SchemaNode, stmt: Statement, sctx: SchemaContext) -> None:
         xpp = XPathParser(stmt.argument, sctx)
         mex = xpp.parse()
         if not xpp.at_end():
             raise InvalidArgument(stmt.argument)
         self.must.append(Must(mex, *stmt.get_error_info()))
 
-    def _when_stmt(self, stmt: Statement, sctx: SchemaContext) -> None:
+    def _when_stmt(self: SchemaNode, stmt: Statement, sctx: SchemaContext) -> None:
         xpp = XPathParser(stmt.argument, sctx)
         wex = xpp.parse()
         if not xpp.at_end():
             raise InvalidArgument(stmt.argument)
         self.when = wex
 
-    def _mandatory_stmt(self, stmt, sctx: SchemaContext) -> None:
+    def _mandatory_stmt(self: SchemaNode, stmt, sctx: SchemaContext) -> None:
         if stmt.argument == "true":
             self._mandatory = True
         elif stmt.argument == "false":
             self._mandatory = False
 
-    def _post_process(self) -> None:
+    def _post_process(self: SchemaNode) -> None:
         pass
 
-    def _is_identityref(self) -> bool:
+    def _is_identityref(self: SchemaNode) -> bool:
         return False
 
-    def _default_nodes(self, inst: "InstanceNode") -> List["InstanceNode"]:
+    def _default_nodes(self: SchemaNode, inst: "InstanceNode") -> List["InstanceNode"]:
         return []
 
-    def _tree_line(self, no_type: bool = False) -> str:
+    def _tree_line(self: SchemaNode, no_type: bool = False) -> str:
         """Return the receiver's contribution to tree diagram."""
         return f"{self._tree_line_prefix()} {self._tree_name()}"
 
-    def _tree_line_prefix(self) -> str:
+    def _tree_line_prefix(self: SchemaNode) -> str:
         return "+--"
 
-    def _nacm_default_deny_stmt(self, stmt: Statement,
+    def _nacm_default_deny_stmt(self: SchemaNode, stmt: Statement,
                                 sctx: SchemaContext) -> None:
         """Set NACM default access."""
         if not hasattr(self, 'default_deny'):
@@ -364,18 +365,18 @@ class SchemaNode:
 class InternalNode(SchemaNode):
     """Abstract class for schema nodes that have children."""
 
-    def __init__(self):
+    def __init__(self: InternalNode):
         """Initialize the class instance."""
         super().__init__()
         self.children: List[SchemaNode] = []
         self._mandatory_children: MutableSet[SchemaNode] = set()
 
     @property
-    def mandatory(self) -> bool:
+    def mandatory(self: InternalNode) -> bool:
         """Is the receiver a mandatory node?"""
         return len(self._mandatory_children) > 0
 
-    def get_child(self, name: YangIdentifier,
+    def get_child(self: InternalNode, name: YangIdentifier,
                   ns: YangIdentifier = None) -> Optional[SchemaNode]:
         """Return receiver's schema child.
 
@@ -396,7 +397,7 @@ class InternalNode(SchemaNode):
                 return grandchild
 
     def get_schema_descendant(
-            self, route: SchemaRoute) -> Optional[SchemaNode]:
+            self: InternalNode, route: SchemaRoute) -> Optional[SchemaNode]:
         """Return descendant schema node or ``None`` if not found.
 
         Args:
@@ -413,7 +414,7 @@ class InternalNode(SchemaNode):
                 return None
         return node
 
-    def get_data_child(self, name: YangIdentifier,
+    def get_data_child(self: InternalNode, name: YangIdentifier,
                        ns: YangIdentifier = None) -> Optional["DataNode"]:
         """Return data node directly under the receiver."""
         ns = ns if ns else self.ns
@@ -430,7 +431,7 @@ class InternalNode(SchemaNode):
             if res:
                 return res
 
-    def filter_children(self, ctype: ContentType = None) -> List[SchemaNode]:
+    def filter_children(self: InternalNode, ctype: ContentType = None) -> List[SchemaNode]:
         """Return receiver's children based on content type.
 
         Args:
@@ -442,7 +443,7 @@ class InternalNode(SchemaNode):
                 not isinstance(c, (RpcActionNode, NotificationNode)) and
                 c.content_type().value & ctype.value != 0]
 
-    def data_children(self) -> List["DataNode"]:
+    def data_children(self: InternalNode) -> List["DataNode"]:
         """Return the set of all data nodes directly under the receiver."""
         res = []
         for child in self.children:
@@ -452,7 +453,7 @@ class InternalNode(SchemaNode):
                 res.extend(child.data_children())
         return res
 
-    def from_raw(self, rval: RawObject, jptr: JSONPointer = "", allow_nodata: bool = False) -> ObjectValue:
+    def from_raw(self: InternalNode, rval: RawObject, jptr: JSONPointer = "", allow_nodata: bool = False) -> ObjectValue:
         """Override the superclass method."""
         if not isinstance(rval, dict):
             raise RawTypeError(jptr, "object")
@@ -481,7 +482,7 @@ class InternalNode(SchemaNode):
                 res[iname] = ch.from_raw(rval[qn], npath)
         return res
 
-    def from_xml(self, rval: ET.Element, jptr: JSONPointer = "", isroot: bool = False, allow_nodata: bool = False) -> ObjectValue:
+    def from_xml(self: InternalNode, rval: ET.Element, jptr: JSONPointer = "", isroot: bool = False, allow_nodata: bool = False) -> ObjectValue:
         res = ObjectValue()
         if isroot:
             self._process_xmlobj_child(res, None, rval, jptr, allow_nodata)
@@ -491,7 +492,7 @@ class InternalNode(SchemaNode):
         return res
 
     def _process_xmlobj_child(
-            self, res: ObjectValue, rval: ET.Element,
+            self: InternalNode, res: ObjectValue, rval: ET.Element,
             xmlchild: ET.Element, jptr: JSONPointer, allow_nodata):
         if xmlchild.tag[0] == '{':
             xmlns, name = xmlchild.tag[1:].split('}')
@@ -524,7 +525,7 @@ class InternalNode(SchemaNode):
         else:
             res[iname] = ch.from_xml(xmlchild, npath)
 
-    def _process_metadata(self, rmo: RawMetadataObject,
+    def _process_metadata(self: InternalNode, rmo: RawMetadataObject,
                           jptr: JSONPointer) -> MetadataObject:
         res = {}
         ans = self.schema_root().annotations
@@ -538,7 +539,7 @@ class InternalNode(SchemaNode):
                 raise AnnotationTypeError(jptr, mem, an.type.error_message)
         return res
 
-    def _node_digest(self) -> Dict[str, Any]:
+    def _node_digest(self: InternalNode) -> Dict[str, Any]:
         res = super()._node_digest()
         rc = res["children"] = {}
         for c in self.data_children():
@@ -549,7 +550,7 @@ class InternalNode(SchemaNode):
             rc[c.iname()] = c._node_digest()
         return res
 
-    def _validate(self, inst: "InstanceNode", scope: ValidationScope,
+    def _validate(self: InternalNode, inst: "InstanceNode", scope: ValidationScope,
                   ctype: ContentType) -> None:
         """Extend the superclass method."""
         if scope.value & ValidationScope.syntax.value:   # schema
@@ -558,15 +559,15 @@ class InternalNode(SchemaNode):
             inst._member(m).validate(scope, ctype)
         super()._validate(inst, scope, ctype)
 
-    def _add_child(self, node: SchemaNode) -> None:
+    def _add_child(self: InternalNode, node: SchemaNode) -> None:
         node.parent = self
         self.children.append(node)
 
-    def _child_inst_names(self) -> Set[InstanceName]:
+    def _child_inst_names(self: InternalNode) -> Set[InstanceName]:
         """Return the set of instance names under the receiver."""
         return frozenset([c.iname() for c in self.data_children()])
 
-    def _check_schema_pattern(self, inst: "InstanceNode",
+    def _check_schema_pattern(self: InternalNode, inst: "InstanceNode",
                               ctype: ContentType) -> None:
         p = self.schema_pattern
         p._eval_when(inst)
@@ -585,14 +586,14 @@ class InternalNode(SchemaNode):
                 inst.json_pointer(), "missing-data",
                 "expected " + msg + ", ".join([repr(m) for m in mms]))
 
-    def _make_schema_patterns(self) -> None:
+    def _make_schema_patterns(self: InternalNode) -> None:
         """Build schema pattern for the receiver and its data descendants."""
         self.schema_pattern = self._schema_pattern()
         for dc in self.data_children():
             if isinstance(dc, InternalNode):
                 dc._make_schema_patterns()
 
-    def _schema_pattern(self) -> SchemaPattern:
+    def _schema_pattern(self: InternalNode) -> SchemaPattern:
         todo = [c for c in self.children
                 if not isinstance(c, (RpcActionNode, NotificationNode))]
         if not todo:
@@ -602,16 +603,16 @@ class InternalNode(SchemaNode):
             prev = Pair(c._pattern_entry(), prev)
         return ConditionalPattern(prev, self.when) if self.when else prev
 
-    def _post_process(self) -> None:
+    def _post_process(self: InternalNode) -> None:
         super()._post_process()
         for c in self.children:
             c._post_process()
 
-    def _add_mandatory_child(self, node: SchemaNode) -> None:
+    def _add_mandatory_child(self: InternalNode, node: SchemaNode) -> None:
         """Add `node` to the set of mandatory children."""
         self._mandatory_children.add(node)
 
-    def _add_defaults(self, inst: "InstanceNode", ctype: ContentType,
+    def _add_defaults(self: InternalNode, inst: "InstanceNode", ctype: ContentType,
                       lazy: bool = False) -> "InstanceNode":
         for c in self.filter_children(ctype):
             if isinstance(c, DataNode):
@@ -620,7 +621,7 @@ class InternalNode(SchemaNode):
                 inst = c._add_defaults(inst, ctype)
         return inst
 
-    def _state_roots(self) -> List[SchemaNode]:
+    def _state_roots(self: InternalNode) -> List[SchemaNode]:
         if self.content_type() == ContentType.nonconfig:
             return [self]
         res = []
@@ -628,7 +629,7 @@ class InternalNode(SchemaNode):
             res.extend(c._state_roots())
         return res
 
-    def _handle_child(self, node: SchemaNode, stmt: Statement,
+    def _handle_child(self: InternalNode, node: SchemaNode, stmt: Statement,
                       sctx: SchemaContext) -> None:
         """Add child node to the receiver and handle substatements."""
         if not sctx.schema_data.if_features(stmt, sctx.text_mid):
@@ -639,7 +640,7 @@ class InternalNode(SchemaNode):
         self._add_child(node)
         node._handle_substatements(stmt, sctx)
 
-    def _augment_stmt(self, stmt: Statement, sctx: SchemaContext) -> None:
+    def _augment_stmt(self: InternalNode, stmt: Statement, sctx: SchemaContext) -> None:
         """Handle **augment** statement."""
         if not sctx.schema_data.if_features(stmt, sctx.text_mid):
             return
@@ -653,7 +654,7 @@ class InternalNode(SchemaNode):
             target = gr
         target._handle_substatements(stmt, sctx)
 
-    def _refine_stmt(self, stmt: Statement, sctx: SchemaContext) -> None:
+    def _refine_stmt(self: InternalNode, stmt: Statement, sctx: SchemaContext) -> None:
         """Handle **refine** statement."""
         target = self.get_schema_descendant(
             sctx.schema_data.sni2route(stmt.argument, sctx))
@@ -664,7 +665,7 @@ class InternalNode(SchemaNode):
         else:
             target._handle_substatements(stmt, sctx)
 
-    def _uses_stmt(self, stmt: Statement, sctx: SchemaContext) -> None:
+    def _uses_stmt(self: InternalNode, stmt: Statement, sctx: SchemaContext) -> None:
         """Handle uses statement."""
         if not sctx.schema_data.if_features(stmt, sctx.text_mid):
             return
@@ -686,11 +687,11 @@ class InternalNode(SchemaNode):
         for refst in stmt.find_all("refine"):
             sn._refine_stmt(refst, sctx)
 
-    def _container_stmt(self, stmt: Statement, sctx: SchemaContext) -> None:
+    def _container_stmt(self: InternalNode, stmt: Statement, sctx: SchemaContext) -> None:
         """Handle container statement."""
         self._handle_child(ContainerNode(), stmt, sctx)
 
-    def _identity_stmt(self, stmt: Statement, sctx: SchemaContext) -> None:
+    def _identity_stmt(self: InternalNode, stmt: Statement, sctx: SchemaContext) -> None:
         """Handle identity statement."""
         if not sctx.schema_data.if_features(stmt, sctx.text_mid):
             return
@@ -704,45 +705,45 @@ class InternalNode(SchemaNode):
             badj.derivs.add(id)
         sctx.schema_data.identity_adjs[id] = adj
 
-    def _list_stmt(self, stmt: Statement, sctx: SchemaContext) -> None:
+    def _list_stmt(self: InternalNode, stmt: Statement, sctx: SchemaContext) -> None:
         """Handle list statement."""
         self._handle_child(ListNode(), stmt, sctx)
 
-    def _choice_stmt(self, stmt: Statement, sctx: SchemaContext) -> None:
+    def _choice_stmt(self: InternalNode, stmt: Statement, sctx: SchemaContext) -> None:
         """Handle choice statement."""
         self._handle_child(ChoiceNode(), stmt, sctx)
 
-    def _case_stmt(self, stmt: Statement, sctx: SchemaContext) -> None:
+    def _case_stmt(self: InternalNode, stmt: Statement, sctx: SchemaContext) -> None:
         """Handle case statement."""
         self._handle_child(CaseNode(), stmt, sctx)
 
-    def _leaf_stmt(self, stmt: Statement, sctx: SchemaContext) -> None:
+    def _leaf_stmt(self: InternalNode, stmt: Statement, sctx: SchemaContext) -> None:
         """Handle leaf statement."""
         node = LeafNode()
         node.type = DataType._resolve_type(
             stmt.find1("type", required=True), sctx)
         self._handle_child(node, stmt, sctx)
 
-    def _leaf_list_stmt(self, stmt: Statement, sctx: SchemaContext) -> None:
+    def _leaf_list_stmt(self: InternalNode, stmt: Statement, sctx: SchemaContext) -> None:
         """Handle leaf-list statement."""
         node = LeafListNode()
         node.type = DataType._resolve_type(
             stmt.find1("type", required=True), sctx)
         self._handle_child(node, stmt, sctx)
 
-    def _rpc_action_stmt(self, stmt: Statement, sctx: SchemaContext) -> None:
+    def _rpc_action_stmt(self: InternalNode, stmt: Statement, sctx: SchemaContext) -> None:
         """Handle rpc or action statement."""
         self._handle_child(RpcActionNode(), stmt, sctx)
 
-    def _notification_stmt(self, stmt: Statement, sctx: SchemaContext) -> None:
+    def _notification_stmt(self: InternalNode, stmt: Statement, sctx: SchemaContext) -> None:
         """Handle notification statement."""
         self._handle_child(NotificationNode(), stmt, sctx)
 
-    def _anydata_stmt(self, stmt: Statement, sctx: SchemaContext) -> None:
+    def _anydata_stmt(self: InternalNode, stmt: Statement, sctx: SchemaContext) -> None:
         """Handle anydata statement."""
         self._handle_child(AnydataNode(), stmt, sctx)
 
-    def _ascii_tree(self, indent: str, no_types: bool, val_count: bool) -> str:
+    def _ascii_tree(self: InternalNode, indent: str, no_types: bool, val_count: bool) -> str:
         """Return the receiver's subtree as ASCII art."""
         def suffix(sn):
             return f" {{{sn.val_count}}}\n" if val_count else "\n"
@@ -759,7 +760,7 @@ class InternalNode(SchemaNode):
         return (res + indent + cs[-1]._tree_line(no_types) + suffix(cs[-1]) +
                 cs[-1]._ascii_tree(indent + "   ", no_types, val_count))
 
-    def clear_val_counters(self) -> None:
+    def clear_val_counters(self: InternalNode) -> None:
         """Clear validation counters in the receiver and its subtree."""
         super().clear_val_counters()
         for c in self.children:
@@ -769,7 +770,7 @@ class InternalNode(SchemaNode):
 class GroupNode(InternalNode):
     """Anonymous group of schema nodes."""
 
-    def _handle_child(self, node: SchemaNode, stmt: Statement,
+    def _handle_child(self: GroupNode, node: SchemaNode, stmt: Statement,
                       sctx: SchemaContext) -> None:
         if not isinstance(
                 self.parent, ChoiceNode) or isinstance(node, CaseNode):
@@ -781,10 +782,10 @@ class GroupNode(InternalNode):
             self._add_child(cn)
             cn._handle_child(node, stmt, sctx)
 
-    def _pattern_entry(self) -> SchemaPattern:
+    def _pattern_entry(self: GroupNode) -> SchemaPattern:
         return super()._schema_pattern()
 
-    def _flatten(self) -> List[SchemaNode]:
+    def _flatten(self: GroupNode) -> List[SchemaNode]:
         res = []
         for c in self.children:
             res.extend(c._flatten())
@@ -794,17 +795,17 @@ class GroupNode(InternalNode):
 class SchemaTreeNode(GroupNode):
     """Root node of a schema tree."""
 
-    def __init__(self, schemadata: "SchemaData" = None):
+    def __init__(self: SchemaTreeNode, schemadata: "SchemaData" = None):
         """Initialize the class instance."""
         super().__init__()
         self.annotations: Dict[QualName, Annotation] = {}
         self.schema_data = schemadata
 
-    def data_parent(self) -> InternalNode:
+    def data_parent(self: SchemaTreeNode) -> InternalNode:
         """Override the superclass method."""
         return self.parent
 
-    def _annotation_stmt(self, stmt: Statement, sctx: SchemaContext) -> None:
+    def _annotation_stmt(self: SchemaTreeNode, stmt: Statement, sctx: SchemaContext) -> None:
         """Handle annotation statement."""
         if not sctx.schema_data.if_features(stmt, sctx.text_mid):
             return
@@ -817,12 +818,12 @@ class SchemaTreeNode(GroupNode):
 class DataNode(SchemaNode):
     """Abstract superclass for all data nodes."""
 
-    def __init__(self):
+    def __init__(self: DataNode):
         """Initialize the class instance."""
         super().__init__()
         self.default_deny: "DefaultDeny" = DefaultDeny.none
 
-    def orphan_instance(self, rval: RawValue) -> "ObjectMember":
+    def orphan_instance(self: DataNode, rval: RawValue) -> "ObjectMember":
         """Return an isolated instance of the receiver.
 
         Args:
@@ -831,7 +832,7 @@ class DataNode(SchemaNode):
         val = self.from_raw(rval)
         return ObjectMember(self.iname(), {}, val, None, self, datetime.now())
 
-    def split_instance_route(self, route: "InstanceRoute") -> Optional[Tuple[
+    def split_instance_route(self: DataNode, route: "InstanceRoute") -> Optional[Tuple[
             "InstanceRoute", "InstanceRoute"]]:
         """Split `route` into the part up to receiver and the rest.
 
@@ -867,14 +868,14 @@ class DataNode(SchemaNode):
             if i >= len(route):
                 return None
 
-    def _validate(self, inst: "InstanceNode", scope: ValidationScope,
+    def _validate(self: DataNode, inst: "InstanceNode", scope: ValidationScope,
                   ctype: ContentType) -> None:
         """Extend the superclass method."""
         if scope.value & ValidationScope.semantics.value:
             self._check_must(inst)        # must expressions
         super()._validate(inst, scope, ctype)
 
-    def _default_instance(self, pnode: "InstanceNode", ctype: ContentType,
+    def _default_instance(self: DataNode, pnode: "InstanceNode", ctype: ContentType,
                           lazy: bool = False) -> "InstanceNode":
         iname = self.iname()
         if iname in pnode.value:
@@ -886,17 +887,17 @@ class DataNode(SchemaNode):
                 return wd.up()
         return pnode
 
-    def _check_must(self, inst: "InstanceNode") -> None:
+    def _check_must(self: DataNode, inst: "InstanceNode") -> None:
         for m in self.must:
             if not m.expression.evaluate(inst):
                 raise SemanticError(inst.json_pointer(), m.error_tag,
                                     m.error_message)
 
-    def _pattern_entry(self) -> SchemaPattern:
+    def _pattern_entry(self: DataNode) -> SchemaPattern:
         m = Member(self.iname(), self.content_type(), self.when)
         return m if self.mandatory else SchemaPattern.optional(m)
 
-    def _tree_line_prefix(self) -> str:
+    def _tree_line_prefix(self: DataNode) -> str:
         return super()._tree_line_prefix() + (
             "ro" if self.content_type() == ContentType.nonconfig else "rw")
 
@@ -904,33 +905,33 @@ class DataNode(SchemaNode):
 class TerminalNode(SchemaNode):
     """Abstract superclass for terminal nodes in the schema tree."""
 
-    def __init__(self):
+    def __init__(self: TerminalNode):
         """Initialize the class instance."""
         super().__init__()
         self.type: DataType = None
         self._default: Optional[Value] = None
 
-    def content_type(self) -> ContentType:
+    def content_type(self: TerminalNode) -> ContentType:
         """Override superclass method."""
         if self._ctype:
             return self._ctype
         return (ContentType.config if self.parent.config else
                 ContentType.nonconfig)
 
-    def from_raw(self, rval: RawScalar, jptr: JSONPointer = "") -> ScalarValue:
+    def from_raw(self: TerminalNode, rval: RawScalar, jptr: JSONPointer = "") -> ScalarValue:
         """Override the superclass method."""
         res = self.type.from_raw(rval)
         if res is None:
             raise RawTypeError(jptr, self.type.yang_type() + " value")
         return res
 
-    def from_xml(self, rval: ET.Element, jptr: JSONPointer = "") -> Value:
+    def from_xml(self: TerminalNode, rval: ET.Element, jptr: JSONPointer = "") -> Value:
         res = self.type.from_xml(rval)
         if res is None:
             raise RawTypeError(jptr, self.type.yang_type() + " value")
         return res
 
-    def _node_digest(self) -> Dict[str, Any]:
+    def _node_digest(self: TerminalNode) -> Dict[str, Any]:
         res = super()._node_digest()
         res["type"] = self.type._type_digest(self.config)
         df = self.default
@@ -938,7 +939,7 @@ class TerminalNode(SchemaNode):
             res["default"] = self.type.to_raw(df)
         return res
 
-    def _validate(self, inst: "InstanceNode", scope: ValidationScope,
+    def _validate(self: TerminalNode, inst: "InstanceNode", scope: ValidationScope,
                   ctype: ContentType) -> None:
         """Extend the superclass method."""
         if (scope.value & ValidationScope.syntax.value and
@@ -956,64 +957,64 @@ class TerminalNode(SchemaNode):
                 raise SemanticError(inst.json_pointer(expand_keys=True), "instance-required")
         super()._validate(inst, scope, ctype)
 
-    def _default_value(self, inst: "InstanceNode", ctype: ContentType,
+    def _default_value(self: TerminalNode, inst: "InstanceNode", ctype: ContentType,
                        lazy: bool) -> "InstanceNode":
         inst.value = self.default
         return inst
 
-    def _post_process(self) -> None:
+    def _post_process(self: TerminalNode) -> None:
         super()._post_process()
         self.type._post_process(self)
 
-    def _is_identityref(self) -> bool:
+    def _is_identityref(self: TerminalNode) -> bool:
         return isinstance(self.type, IdentityrefType)
 
-    def _default_nodes(self, inst: "InstanceNode") -> List["InstanceNode"]:
+    def _default_nodes(self: TerminalNode, inst: "InstanceNode") -> List["InstanceNode"]:
         di = self._default_instance(inst, ContentType.all)
         return [] if di is None else [self]
 
-    def _ascii_tree(self, indent: str, no_types: bool, val_count: bool) -> str:
+    def _ascii_tree(self: TerminalNode, indent: str, no_types: bool, val_count: bool) -> str:
         return ""
 
-    def _state_roots(self) -> List[SchemaNode]:
+    def _state_roots(self: TerminalNode) -> List[SchemaNode]:
         return [] if self.content_type() == ContentType.config else [self]
 
 
 class ContainerNode(DataNode, InternalNode):
     """Container node."""
 
-    def __init__(self):
+    def __init__(self: ContainerNode):
         """Initialize the class instance."""
         super().__init__()
         self.presence: bool = False
 
     @property
-    def mandatory(self) -> bool:
+    def mandatory(self: ContainerNode) -> bool:
         """Is the receiver a mandatory node?"""
         return not self.presence and super().mandatory
 
-    def _node_digest(self) -> Dict[str, Any]:
+    def _node_digest(self: ContainerNode) -> Dict[str, Any]:
         res = super()._node_digest()
         res["presence"] = self.presence
         return res
 
-    def _add_mandatory_child(self, node: SchemaNode):
+    def _add_mandatory_child(self: ContainerNode, node: SchemaNode):
         if not (self.presence or self.mandatory):
             self.parent._add_mandatory_child(self)
         super()._add_mandatory_child(node)
 
-    def _default_instance(self, pnode: "InstanceNode", ctype: ContentType,
+    def _default_instance(self: ContainerNode, pnode: "InstanceNode", ctype: ContentType,
                           lazy: bool = False) -> "InstanceNode":
         if self.presence:
             return pnode
         return super()._default_instance(pnode, ctype, lazy)
 
-    def _default_value(self, inst: "InstanceNode", ctype: ContentType,
+    def _default_value(self: ContainerNode, inst: "InstanceNode", ctype: ContentType,
                        lazy: bool) -> Optional["InstanceNode"]:
         inst.value = ObjectValue()
         return inst if lazy else self._add_defaults(inst, ctype)
 
-    def _default_nodes(self, inst: "InstanceNode") -> List["InstanceNode"]:
+    def _default_nodes(self: ContainerNode, inst: "InstanceNode") -> List["InstanceNode"]:
         if self.presence:
             return []
         res = inst.put_member(self.iname(), ObjectValue())
@@ -1021,10 +1022,10 @@ class ContainerNode(DataNode, InternalNode):
             return [res]
         return []
 
-    def _presence_stmt(self, stmt: Statement, sctx: SchemaContext) -> None:
+    def _presence_stmt(self: ContainerNode, stmt: Statement, sctx: SchemaContext) -> None:
         self.presence = True
 
-    def _tree_line(self, no_type: bool = False) -> str:
+    def _tree_line(self: ContainerNode, no_type: bool = False) -> str:
         """Return the receiver's contribution to tree diagram."""
         return super()._tree_line() + ("!" if self.presence else "")
 
@@ -1032,7 +1033,7 @@ class ContainerNode(DataNode, InternalNode):
 class SequenceNode(DataNode):
     """Abstract class for data nodes that represent a sequence."""
 
-    def __init__(self):
+    def __init__(self: SequenceNode):
         """Initialize the class instance."""
         super().__init__()
         self.min_elements: int = 0
@@ -1040,11 +1041,11 @@ class SequenceNode(DataNode):
         self.user_ordered: bool = False
 
     @property
-    def mandatory(self) -> bool:
+    def mandatory(self: SequenceNode) -> bool:
         """Is the receiver a mandatory node?"""
         return self.min_elements > 0
 
-    def _validate(self, inst: "InstanceNode", scope: ValidationScope,
+    def _validate(self: SequenceNode, inst: "InstanceNode", scope: ValidationScope,
                   ctype: ContentType) -> None:
         """Extend the superclass method."""
         if isinstance(inst, ArrayEntry):
@@ -1056,36 +1057,36 @@ class SequenceNode(DataNode):
             for e in inst:
                 super()._validate(e, scope, ctype)
 
-    def _check_cardinality(self, inst: "InstanceNode") -> None:
+    def _check_cardinality(self: SequenceNode, inst: "InstanceNode") -> None:
         if len(inst.value) < self.min_elements:
             raise SemanticError(inst.json_pointer(), "too-few-elements")
         if (self.max_elements is not None and
                 len(inst.value) > self.max_elements):
             raise SemanticError(inst.json_pointer(), "too-many-elements")
 
-    def _post_process(self) -> None:
+    def _post_process(self: SequenceNode) -> None:
         super()._post_process()
         if self.min_elements > 0:
             self.parent._add_mandatory_child(self)
 
-    def _min_elements_stmt(self, stmt: Statement, sctx: SchemaContext) -> None:
+    def _min_elements_stmt(self: SequenceNode, stmt: Statement, sctx: SchemaContext) -> None:
         self.min_elements = int(stmt.argument)
 
-    def _max_elements_stmt(self, stmt: Statement, sctx: SchemaContext) -> None:
+    def _max_elements_stmt(self: SequenceNode, stmt: Statement, sctx: SchemaContext) -> None:
         arg = stmt.argument
         if arg == "unbounded":
             self.max_elements = None
         else:
             self.max_elements = int(arg)
 
-    def _ordered_by_stmt(self, stmt: Statement, sctx: SchemaContext) -> None:
+    def _ordered_by_stmt(self: SequenceNode, stmt: Statement, sctx: SchemaContext) -> None:
         self.user_ordered = stmt.argument == "user"
 
-    def _tree_line(self, no_type: bool = False) -> str:
+    def _tree_line(self: SequenceNode, no_type: bool = False) -> str:
         """Extend the superclass method."""
         return super()._tree_line() + "*"
 
-    def from_raw(self, rval: RawList, jptr: JSONPointer = "") -> ArrayValue:
+    def from_raw(self: SequenceNode, rval: RawList, jptr: JSONPointer = "") -> ArrayValue:
         """Override the superclass method."""
         if not isinstance(rval, list):
             raise RawTypeError(jptr, "array")
@@ -1101,7 +1102,7 @@ class SequenceNode(DataNode):
             idx = idx + 1
         return res
 
-    def from_xml(self, rval: ET.Element, jptr: JSONPointer = "",
+    def from_xml(self: SequenceNode, rval: ET.Element, jptr: JSONPointer = "",
                  tagname: str = None, isroot: bool = False) -> ArrayValue:
         res = ArrayValue()
         idx = 0
@@ -1120,7 +1121,7 @@ class SequenceNode(DataNode):
         return res
 
     def _process_xmlarray_child(
-            self, res: ArrayValue, xmlchild: ET.Element,
+            self: SequenceNode, res: ArrayValue, xmlchild: ET.Element,
             tagname: str, jptr: JSONPointer):
         if xmlchild.tag[0] == '{':
             xmlns, name = xmlchild.tag[1:].split('}')
@@ -1139,7 +1140,7 @@ class SequenceNode(DataNode):
             child = None
         return child
 
-    def entry_from_raw(self, rval: RawEntry,
+    def entry_from_raw(self: SequenceNode, rval: RawEntry,
                        jptr: JSONPointer = "") -> EntryValue:
         """Transform a raw (leaf-)list entry into the cooked form.
 
@@ -1154,7 +1155,7 @@ class SequenceNode(DataNode):
         """
         return super().from_raw(rval, jptr)
 
-    def entry_from_xml(self, rval: ET.Element, jptr: JSONPointer = "") -> EntryValue:
+    def entry_from_xml(self: SequenceNode, rval: ET.Element, jptr: JSONPointer = "") -> EntryValue:
         """Transform a XML (leaf-)list entry into the cooked form.
 
         Args:
@@ -1172,26 +1173,26 @@ class SequenceNode(DataNode):
 class ListNode(SequenceNode, InternalNode):
     """List node."""
 
-    def __init__(self):
+    def __init__(self: ListNode):
         """Initialize the class instance."""
         super().__init__()
         self.keys: List[QualName] = []
         self._key_members = []
         self.unique: List[List[LocationPath]] = []
 
-    def _node_digest(self) -> Dict[str, Any]:
+    def _node_digest(self: ListNode) -> Dict[str, Any]:
         res = super()._node_digest()
         res["keys"] = self._key_members
         return res
 
-    def _check_list_props(self, inst: "InstanceNode") -> None:
+    def _check_list_props(self: ListNode, inst: "InstanceNode") -> None:
         """Check uniqueness of keys and "unique" properties, if applicable."""
         if self.keys:
             self._check_keys(inst)
         for u in self.unique:
             self._check_unique(u, inst)
 
-    def _check_keys(self, inst: "InstanceNode") -> None:
+    def _check_keys(self: ListNode, inst: "InstanceNode") -> None:
         ukeys = set()
         for i in range(len(inst.value)):
             en = inst.value[i]
@@ -1206,7 +1207,7 @@ class ListNode(SequenceNode, InternalNode):
                     repr(kval[0] if len(kval) < 2 else kval))
             ukeys.add(kval)
 
-    def _check_unique(self, unique: List[LocationPath],
+    def _check_unique(self: ListNode, unique: List[LocationPath],
                       inst: "InstanceNode") -> None:
         allvals = set()
         for en in inst:
@@ -1221,11 +1222,11 @@ class ListNode(SequenceNode, InternalNode):
             else:
                 allvals |= tups
 
-    def _default_instance(self, pnode: "InstanceNode", ctype: ContentType,
+    def _default_instance(self: ListNode, pnode: "InstanceNode", ctype: ContentType,
                           lazy: bool = False) -> "InstanceNode":
         return pnode
 
-    def _post_process(self) -> None:
+    def _post_process(self: ListNode) -> None:
         super()._post_process()
         for k in self.keys:
             kn = self.get_data_child(*k)
@@ -1234,12 +1235,12 @@ class ListNode(SequenceNode, InternalNode):
                 kn._mandatory = True
                 self._mandatory_children.add(kn)
 
-    def _key_stmt(self, stmt: Statement, sctx: SchemaContext) -> None:
+    def _key_stmt(self: ListNode, stmt: Statement, sctx: SchemaContext) -> None:
         self.keys = []
         for k in stmt.argument.split():
             self.keys.append(sctx.schema_data.translate_node_id(k, sctx))
 
-    def _unique_stmt(self, stmt: Statement, sctx: SchemaContext) -> None:
+    def _unique_stmt(self: ListNode, stmt: Statement, sctx: SchemaContext) -> None:
         uspec = []
         for sid in stmt.argument.split():
             xpp = XPathParser(sid, sctx)
@@ -1249,13 +1250,13 @@ class ListNode(SequenceNode, InternalNode):
             uspec.append(uex)
         self.unique.append(uspec)
 
-    def _tree_line(self, no_type: bool = False) -> str:
+    def _tree_line(self: ListNode, no_type: bool = False) -> str:
         """Return the receiver's contribution to tree diagram."""
         keys = (" [" + " ".join([k[0] for k in self.keys]) + "]"
                 if self.keys else "")
         return super()._tree_line() + keys
 
-    def orphan_entry(self, rval: RawObject) -> "ArrayEntry":
+    def orphan_entry(self: ListNode, rval: RawObject) -> "ArrayEntry":
         """Return an isolated entry of the receiver.
 
         Args:
@@ -1269,18 +1270,18 @@ class ListNode(SequenceNode, InternalNode):
 class ChoiceNode(InternalNode):
     """Choice node."""
 
-    def __init__(self):
+    def __init__(self: ChoiceNode):
         """Initialize the class instance."""
         super().__init__()
         self.default_case: QualName = None
         self._mandatory: bool = False
 
     @property
-    def mandatory(self) -> bool:
+    def mandatory(self: ChoiceNode) -> bool:
         """Is the receiver a mandatory node?"""
         return self._mandatory
 
-    def _add_defaults(self, inst: "InstanceNode",
+    def _add_defaults(self: ChoiceNode, inst: "InstanceNode",
                       ctype: ContentType) -> "InstanceNode":
         if self.when and not self.when.evaluate(inst):
             return inst
@@ -1297,14 +1298,14 @@ class ChoiceNode(InternalNode):
         else:
             return inst
 
-    def _active_case(self, value: ObjectValue) -> Optional["CaseNode"]:
+    def _active_case(self: ChoiceNode, value: ObjectValue) -> Optional["CaseNode"]:
         """Return receiver's case that's active in an instance node value."""
         for c in self.children:
             for cc in c.data_children():
                 if cc.iname() in value:
                     return c
 
-    def _pattern_entry(self) -> SchemaPattern:
+    def _pattern_entry(self: ChoiceNode) -> SchemaPattern:
         if not self.children:
             return Empty()
         prev = self.children[0]._schema_pattern()
@@ -1315,12 +1316,12 @@ class ChoiceNode(InternalNode):
             prev = SchemaPattern.optional(prev)
         return ConditionalPattern(prev, self.when) if self.when else prev
 
-    def _post_process(self) -> None:
+    def _post_process(self: ChoiceNode) -> None:
         super()._post_process()
         if self._mandatory:
             self.parent._add_mandatory_child(self)
 
-    def _default_nodes(self, inst: "InstanceNode") -> List["InstanceNode"]:
+    def _default_nodes(self: ChoiceNode, inst: "InstanceNode") -> List["InstanceNode"]:
         res = []
         if self.default_case is None:
             return res
@@ -1328,11 +1329,11 @@ class ChoiceNode(InternalNode):
             res.extend(cn._default_nodes(inst))
         return res
 
-    def _tree_line_prefix(self) -> str:
+    def _tree_line_prefix(self: ChoiceNode) -> str:
         return super()._tree_line_prefix() + (
             "ro" if self.content_type() == ContentType.nonconfig else "rw")
 
-    def _handle_child(self, node: SchemaNode, stmt: Statement,
+    def _handle_child(self: ChoiceNode, node: SchemaNode, stmt: Statement,
                       sctx: SchemaContext) -> None:
         if isinstance(node, CaseNode):
             super()._handle_child(node, stmt, sctx)
@@ -1343,11 +1344,11 @@ class ChoiceNode(InternalNode):
             self._add_child(cn)
             cn._handle_child(node, stmt, sctx)
 
-    def _default_stmt(self, stmt: Statement, sctx: SchemaContext) -> None:
+    def _default_stmt(self: ChoiceNode, stmt: Statement, sctx: SchemaContext) -> None:
         self.default_case = sctx.schema_data.translate_node_id(
             stmt.argument, sctx)
 
-    def _tree_line(self, no_type: bool = False) -> str:
+    def _tree_line(self: ChoiceNode, no_type: bool = False) -> str:
         """Return the receiver's contribution to tree diagram."""
         return f"{self._tree_line_prefix()} ({self._tree_name()})" \
             f"{'' if self._mandatory else '?'}"
@@ -1356,10 +1357,10 @@ class ChoiceNode(InternalNode):
 class CaseNode(InternalNode):
     """Case node."""
 
-    def _pattern_entry(self) -> SchemaPattern:
+    def _pattern_entry(self: CaseNode) -> SchemaPattern:
         return super()._schema_pattern()
 
-    def _tree_line(self, no_type: bool = False) -> str:
+    def _tree_line(self: CaseNode, no_type: bool = False) -> str:
         """Return the receiver's contribution to tree diagram."""
         return f"{self._tree_line_prefix()}:({self._tree_name()})"
 
@@ -1367,18 +1368,18 @@ class CaseNode(InternalNode):
 class LeafNode(DataNode, TerminalNode):
     """Leaf node."""
 
-    def __init__(self):
+    def __init__(self: LeafNode):
         """Initialize the class instance."""
         super().__init__()
         self._mandatory: bool = False
 
     @property
-    def mandatory(self) -> bool:
+    def mandatory(self: LeafNode) -> bool:
         """Is the receiver a mandatory node?"""
         return self._mandatory
 
     @property
-    def default(self) -> Optional[ScalarValue]:
+    def default(self: LeafNode) -> Optional[ScalarValue]:
         """Default value of the receiver, if any."""
         if self.mandatory:
             return None
@@ -1386,18 +1387,18 @@ class LeafNode(DataNode, TerminalNode):
             return self._default
         return self.type.default
 
-    def _post_process(self) -> None:
+    def _post_process(self: LeafNode) -> None:
         super()._post_process()
         if self._mandatory:
             self.parent._add_mandatory_child(self)
         elif self._default is not None:
             self._default = self.type.from_yang(self._default)
 
-    def _tree_line(self, no_type: bool = False) -> str:
+    def _tree_line(self: LeafNode, no_type: bool = False) -> str:
         res = super()._tree_line() + ("" if self._mandatory else "?")
         return res if no_type else f"{res} <{self.type}>"
 
-    def _default_stmt(self, stmt: Statement, sctx: SchemaContext) -> None:
+    def _default_stmt(self: LeafNode, stmt: Statement, sctx: SchemaContext) -> None:
         self._default = stmt.argument
 
 
@@ -1405,7 +1406,7 @@ class LeafListNode(SequenceNode, TerminalNode):
     """Leaf-list node."""
 
     @property
-    def default(self) -> Optional[ScalarValue]:
+    def default(self: LeafListNode) -> Optional[ScalarValue]:
         """Default value of the receiver, if any."""
         if self.mandatory:
             return None
@@ -1414,28 +1415,28 @@ class LeafListNode(SequenceNode, TerminalNode):
         return (None if self.type.default is None
                 else ArrayValue([self.type.default]))
 
-    def _yang_class(self) -> str:
+    def _yang_class(self: LeafListNode) -> str:
         return "leaf-list"
 
-    def _check_list_props(self, inst: "InstanceNode") -> None:
+    def _check_list_props(self: LeafListNode, inst: "InstanceNode") -> None:
         if (self.content_type() == ContentType.config and
                 len(set(inst.value)) < len(inst.value)):
             raise SemanticError(
                 inst.json_pointer(), "repeated-leaf-list-value")
 
-    def _default_stmt(self, stmt: Statement, sctx: SchemaContext) -> None:
+    def _default_stmt(self: LeafListNode, stmt: Statement, sctx: SchemaContext) -> None:
         if self._default is None:
             self._default = [stmt.argument]
         else:
             self._default.append(stmt.argument)
 
-    def _post_process(self) -> None:
+    def _post_process(self: LeafListNode) -> None:
         super()._post_process()
         if self._default is not None:
             self._default = ArrayValue(
                 [self.type.from_yang(v) for v in self._default])
 
-    def _tree_line(self, no_type: bool = False) -> str:
+    def _tree_line(self: LeafListNode, no_type: bool = False) -> str:
         res = super()._tree_line()
         return res if no_type else f"{res} <{self.type}>"
 
@@ -1443,21 +1444,21 @@ class LeafListNode(SequenceNode, TerminalNode):
 class AnyContentNode(DataNode):
     """Abstract class for anydata or anyxml nodes."""
 
-    def __init__(self):
+    def __init__(self: AnyContentNode):
         """Initialize the class instance."""
         super().__init__()
         self._mandatory: bool = False
 
-    def content_type(self) -> ContentType:
+    def content_type(self: AnyContentNode) -> ContentType:
         """Override superclass method."""
         return TerminalNode.content_type(self)
 
     @property
-    def mandatory(self) -> bool:
+    def mandatory(self: AnyContentNode) -> bool:
         """Is the receiver a mandatory node?"""
         return self._mandatory
 
-    def from_raw(self, rval: RawValue, jptr: JSONPointer = "") -> Value:
+    def from_raw(self: AnyContentNode, rval: RawValue, jptr: JSONPointer = "") -> Value:
         """Override the superclass method."""
         def convert(val):
             if isinstance(val, list):
@@ -1469,7 +1470,7 @@ class AnyContentNode(DataNode):
             return res
         return convert(rval)
 
-    def to_raw(self, value: Value) -> RawValue:
+    def to_raw(self: AnyContentNode, value: Value) -> RawValue:
         """Convert the value again to plain Python stuff."""
         def convert(val):
             if isinstance(val, ArrayValue):
@@ -1481,20 +1482,20 @@ class AnyContentNode(DataNode):
             return res
         return convert(value)
 
-    def from_xml(self, rval: ET.Element, jptr: JSONPointer = "") -> Value:
+    def from_xml(self: AnyContentNode, rval: ET.Element, jptr: JSONPointer = "") -> Value:
         super().from_xml(rval, jptr)
 
-    def _default_instance(self, pnode: "InstanceNode", ctype: ContentType,
+    def _default_instance(self: AnyContentNode, pnode: "InstanceNode", ctype: ContentType,
                           lazy: bool = False) -> "InstanceNode":
         return pnode
 
-    def _tree_line(self, no_type: bool = False) -> str:
+    def _tree_line(self: AnyContentNode, no_type: bool = False) -> str:
         return super()._tree_line() + ("" if self._mandatory else "?")
 
-    def _ascii_tree(self, indent: str, no_types: bool, val_count: bool) -> str:
+    def _ascii_tree(self: AnyContentNode, indent: str, no_types: bool, val_count: bool) -> str:
         return ""
 
-    def _post_process(self) -> None:
+    def _post_process(self: AnyContentNode) -> None:
         if self._mandatory:
             self.parent._add_mandatory_child(self)
 
@@ -1512,29 +1513,29 @@ class AnyxmlNode(AnyContentNode):
 class RpcActionNode(SchemaTreeNode):
     """RPC or action node."""
 
-    def __init__(self):
+    def __init__(self: RpcActionNode):
         """Initialize the class instance."""
         super().__init__()
         self.default_deny: "DefaultDeny" = DefaultDeny.none
         self._ctype = ContentType.nonconfig
 
-    def _handle_substatements(self, stmt: Statement,
+    def _handle_substatements(self: RpcActionNode, stmt: Statement,
                               sctx: SchemaContext) -> None:
         self._add_child(InputNode(sctx.default_ns))
         self._add_child(OutputNode(sctx.default_ns))
         super()._handle_substatements(stmt, sctx)
 
-    def _flatten(self) -> List[SchemaNode]:
+    def _flatten(self: RpcActionNode) -> List[SchemaNode]:
         return [self]
 
-    def _tree_line_prefix(self) -> str:
+    def _tree_line_prefix(self: RpcActionNode) -> str:
         return super()._tree_line_prefix() + "-x"
 
-    def _input_stmt(self, stmt: Statement, sctx: SchemaContext) -> None:
+    def _input_stmt(self: RpcActionNode, stmt: Statement, sctx: SchemaContext) -> None:
         """Handle RPC or action input statement."""
         self.get_child("input")._handle_substatements(stmt, sctx)
 
-    def _output_stmt(self, stmt: Statement, sctx: SchemaContext) -> None:
+    def _output_stmt(self: RpcActionNode, stmt: Statement, sctx: SchemaContext) -> None:
         """Handle RPC or action output statement."""
         self.get_child("output")._handle_substatements(stmt, sctx)
 
@@ -1542,44 +1543,44 @@ class RpcActionNode(SchemaTreeNode):
 class InputNode(SchemaTreeNode, DataNode):
     """RPC or action input node."""
 
-    def __init__(self, ns):
+    def __init__(self: InputNode, ns):
         """Initialize the class instance."""
         super().__init__()
         self._config = False
         self.name = "input"
         self.ns = ns
 
-    def _flatten(self) -> List[SchemaNode]:
+    def _flatten(self: InputNode) -> List[SchemaNode]:
         return [self]
 
 
 class OutputNode(SchemaTreeNode, DataNode):
     """RPC or action output node."""
 
-    def __init__(self, ns):
+    def __init__(self: OutputNode, ns):
         """Initialize the class instance."""
         super().__init__()
         self._config = False
         self.name = "output"
         self.ns = ns
 
-    def _flatten(self) -> List[SchemaNode]:
+    def _flatten(self: OutputNode) -> List[SchemaNode]:
         return [self]
 
 
 class NotificationNode(SchemaTreeNode):
     """Notification node."""
 
-    def __init__(self):
+    def __init__(self: NotificationNode):
         """Initialize the class instance."""
         super().__init__()
         self.default_deny: "DefaultDeny" = DefaultDeny.none
         self._ctype = ContentType.nonconfig
 
-    def _flatten(self) -> List[SchemaNode]:
+    def _flatten(self: NotificationNode) -> List[SchemaNode]:
         return [self]
 
-    def _tree_line_prefix(self) -> str:
+    def _tree_line_prefix(self: NotificationNode) -> str:
         return super()._tree_line_prefix() + "-n"
 
 

--- a/yangson/schpattern.py
+++ b/yangson/schpattern.py
@@ -16,6 +16,7 @@
 # with Yangson.  If not, see <http://www.gnu.org/licenses/>.
 
 """This module defines classes for schema patterns."""
+from __future__ import annotations
 
 from typing import List, Optional
 from .enumerations import ContentType
@@ -33,158 +34,158 @@ class SchemaPattern:
         """Make `p` an optional pattern."""
         return Alternative.combine(Empty(), p)
 
-    def nullable(self, ctype: ContentType) -> bool:
+    def nullable(self: SchemaPattern, ctype: ContentType) -> bool:
         """Return ``True`` the receiver is nullable."""
         return False
 
-    def empty(self) -> bool:
+    def empty(self: SchemaPattern) -> bool:
         """Return ``True`` if the receiver is (conditionally) empty."""
         return False
 
-    def _active(self, ctype: ContentType) -> bool:
+    def _active(self: SchemaPattern, ctype: ContentType) -> bool:
         """Return ``True`` the receiver is active in the current context."""
         return True
 
-    def _eval_when(self, cnode: "InstanceNode") -> None:
+    def _eval_when(self: SchemaPattern, cnode: "InstanceNode") -> None:
         return
 
-    def _mandatory_members(self, ctype: ContentType) -> List[InstanceName]:
+    def _mandatory_members(self: SchemaPattern, ctype: ContentType) -> List[InstanceName]:
         return []
 
 
 class Empty(SchemaPattern, metaclass=_Singleton):
     """Singleton class representing the empty pattern."""
 
-    def nullable(self, ctype: ContentType) -> bool:
+    def nullable(self: Empty, ctype: ContentType) -> bool:
         """Override the superclass method."""
         return True
 
-    def deriv(self, x: str, ctype: ContentType) -> SchemaPattern:
+    def deriv(self: Empty, x: str, ctype: ContentType) -> SchemaPattern:
         """Return derivative of the receiver."""
         return NotAllowed()
 
-    def empty(self) -> bool:
+    def empty(self: Empty) -> bool:
         """Override the superclass method."""
         return True
 
-    def tree(self, indent: int = 0):
+    def tree(self: Empty, indent: int = 0):
         return " " * indent + "Empty"
 
-    def __str__(self) -> str:
+    def __str__(self: Empty) -> str:
         return "Empty"
 
 
 class NotAllowed(SchemaPattern, metaclass=_Singleton):
 
-    def deriv(self, x: str, ctype: ContentType) -> SchemaPattern:
+    def deriv(self: NotAllowed, x: str, ctype: ContentType) -> SchemaPattern:
         """Return derivative of the receiver."""
         return self
 
-    def tree(self, indent: int = 0):
+    def tree(self: NotAllowed, indent: int = 0):
         return " " * indent + "NotAllowed"
 
-    def __str__(self) -> str:
+    def __str__(self: NotAllowed) -> str:
         return "NotAllowed"
 
 
 class Conditional(SchemaPattern):
     """Class representing conditional pattern."""
 
-    def __init__(self, when: Expr):
+    def __init__(self: Conditional, when: Expr):
         """Initialize the class instance."""
         self.when = when
         self._val_when = None  # type: bool
 
-    def empty(self) -> bool:
+    def empty(self: Conditional) -> bool:
         """Override the superclass method."""
         return self.when and not self._val_when
 
-    def check_when(self) -> bool:
+    def check_when(self: Conditional) -> bool:
         return not self.when or self._val_when
 
-    def _eval_when(self, cnode: "InstanceNode") -> None:
+    def _eval_when(self: Conditional, cnode: "InstanceNode") -> None:
         self._val_when = bool(self.when.evaluate(cnode))
 
-    def _active(self, ctype: ContentType) -> bool:
+    def _active(self: Conditional, ctype: ContentType) -> bool:
         return super()._active(ctype) and self.check_when()
 
 
 class Typeable(SchemaPattern):
     """Multiple content types and their combinations."""
 
-    def __init__(self, ctype: ContentType):
+    def __init__(self: Typeable, ctype: ContentType):
         """Initialize the class instance."""
         self.ctype = ctype
 
-    def match_ctype(self, ctype) -> bool:
+    def match_ctype(self: Typeable, ctype) -> bool:
         return self.ctype.value & ctype.value != 0
 
-    def _active(self, ctype: ContentType) -> bool:
+    def _active(self: Typeable, ctype: ContentType) -> bool:
         return super()._active(ctype) and self.match_ctype(ctype)
 
 
 class ConditionalPattern(Conditional):
     """Class representing conditional pattern."""
 
-    def __init__(self, p: SchemaPattern, when: Expr):
+    def __init__(self: ConditionalPattern, p: SchemaPattern, when: Expr):
         """Initialize the class instance."""
         super().__init__(when)
         self.pattern = p
 
-    def _eval_when(self, cnode: "InstanceNode") -> None:
+    def _eval_when(self: ConditionalPattern, cnode: "InstanceNode") -> None:
         super()._eval_when(cnode)
         self.pattern._eval_when(cnode)
 
-    def nullable(self, ctype: ContentType) -> bool:
+    def nullable(self: ConditionalPattern, ctype: ContentType) -> bool:
         """Override the superclass method."""
         return (not self.check_when() or self.pattern.nullable(ctype))
 
-    def deriv(self, x: str, ctype: ContentType) -> SchemaPattern:
+    def deriv(self: ConditionalPattern, x: str, ctype: ContentType) -> SchemaPattern:
         """Return derivative of the receiver."""
         return (self.pattern.deriv(x, ctype) if self.check_when() else
                 NotAllowed())
 
-    def tree(self, indent: int = 0):
+    def tree(self: ConditionalPattern, indent: int = 0):
         return (" " * indent + "Conditional\n" +
                 self.pattern.tree(indent + 2))
 
-    def __str__(self) -> str:
+    def __str__(self: ConditionalPattern) -> str:
         return str(self.pattern)
 
-    def _mandatory_members(self, ctype: ContentType) -> List[InstanceName]:
+    def _mandatory_members(self: ConditionalPattern, ctype: ContentType) -> List[InstanceName]:
         return self.pattern._mandatory_members(ctype) if self._active(ctype) else []
 
 
 class Member(Typeable, Conditional):
 
-    def __init__(self, name: InstanceName, ctype: ContentType,
+    def __init__(self: Member, name: InstanceName, ctype: ContentType,
                  when: Optional[Expr]):
         Typeable.__init__(self, ctype)
         Conditional.__init__(self, when)
         self.name = name
 
-    def _eval_when(self, cnode: "InstanceNode") -> None:
+    def _eval_when(self: Member, cnode: "InstanceNode") -> None:
         if self.when:
             dummy = cnode.put_member(self.name, (None,))
             super()._eval_when(dummy)
 
-    def nullable(self, ctype: ContentType) -> bool:
+    def nullable(self: Member, ctype: ContentType) -> bool:
         """Override the superclass method."""
         return not (self._active(ctype))
 
-    def deriv(self, x: str, ctype: ContentType) -> SchemaPattern:
+    def deriv(self: Member, x: str, ctype: ContentType) -> SchemaPattern:
         """Return derivative of the receiver."""
         return (Empty() if
                 self.name == x and self._active(ctype)
                 else NotAllowed())
 
-    def tree(self, indent: int = 0):
+    def tree(self: Member, indent: int = 0):
         return " " * indent + "Member " + self.name
 
-    def __str__(self) -> str:
+    def __str__(self: Member) -> str:
         return f"member '{self.name}'"
 
-    def _mandatory_members(self, ctype: ContentType) -> List[InstanceName]:
+    def _mandatory_members(self: Member, ctype: ContentType) -> List[InstanceName]:
         return [self.name] if self._active(ctype) else []
 
 
@@ -198,33 +199,33 @@ class Alternative(SchemaPattern):
             return p
         return cls(p, q)
 
-    def __init__(self, p: SchemaPattern, q: SchemaPattern):
+    def __init__(self: Alternative, p: SchemaPattern, q: SchemaPattern):
         self.left = p
         self.right = q
 
-    def _eval_when(self, cnode: "InstanceNode") -> None:
+    def _eval_when(self: Alternative, cnode: "InstanceNode") -> None:
         super()._eval_when(cnode)
         self.left._eval_when(cnode)
         self.right._eval_when(cnode)
 
-    def nullable(self, ctype: ContentType) -> bool:
+    def nullable(self: Alternative, ctype: ContentType) -> bool:
         """Override the superclass method."""
         return self.left.nullable(ctype) or self.right.nullable(ctype)
 
-    def deriv(self, x: str, ctype: ContentType) -> SchemaPattern:
+    def deriv(self: Alternative, x: str, ctype: ContentType) -> SchemaPattern:
         """Return derivative of the receiver."""
         return Alternative.combine(self.left.deriv(x, ctype),
                                    self.right.deriv(x, ctype))
 
-    def tree(self, indent: int = 0):
+    def tree(self: Alternative, indent: int = 0):
         return (" " * indent + "Alternative\n" +
                 self.left.tree(indent + 2) + "\n" +
                 self.right.tree(indent + 2))
 
-    def __str__(self) -> str:
+    def __str__(self: Alternative) -> str:
         return f"{self.left!s} or {self.right!s}"
 
-    def _mandatory_members(self, ctype: ContentType) -> List[InstanceName]:
+    def _mandatory_members(self: Alternative, ctype: ContentType) -> List[InstanceName]:
         lm = self.left._mandatory_members(ctype)
         rm = self.right._mandatory_members(ctype)
         return [] if not lm or not rm else lm + rm
@@ -232,25 +233,25 @@ class Alternative(SchemaPattern):
 
 class ChoicePattern(Alternative, Typeable):
 
-    def __init__(self, p: SchemaPattern, q: SchemaPattern,
+    def __init__(self: ChoicePattern, p: SchemaPattern, q: SchemaPattern,
                  name: YangIdentifier):
         super().__init__(p, q)
         self.ctype = ContentType.all  # type: ContentType
         self.name = name
 
-    def nullable(self, ctype: ContentType):
+    def nullable(self: ChoicePattern, ctype: ContentType):
         return not self.match_ctype(ctype)
 
-    def deriv(self, x: str, ctype: ContentType):
+    def deriv(self: ChoicePattern, x: str, ctype: ContentType):
         return (super().deriv(x, ctype) if self.match_ctype(ctype) else
                 NotAllowed())
 
-    def tree(self, indent: int = 0):
+    def tree(self: ChoicePattern, indent: int = 0):
         return (" " * indent +
                 f"Choice {self.name}\n{self.left.tree(indent + 2)}\n"
                 f"{self.right.tree(indent + 2)}")
 
-    def _members(self, ctype: ContentType) -> List[InstanceName]:
+    def _members(self: ChoicePattern, ctype: ContentType) -> List[InstanceName]:
         return super()._members(ctype) if self._active(ctype) else []
 
 
@@ -268,32 +269,32 @@ class Pair(SchemaPattern):
             return q
         return cls(p, q)
 
-    def __init__(self, p: SchemaPattern, q: SchemaPattern):
+    def __init__(self: Pair, p: SchemaPattern, q: SchemaPattern):
         self.left = p
         self.right = q
 
-    def nullable(self, ctype: ContentType) -> bool:
+    def nullable(self: Pair, ctype: ContentType) -> bool:
         """Override the superclass method."""
         return (self.left.nullable(ctype) and
                 self.right.nullable(ctype))
 
-    def deriv(self, x: str, ctype: ContentType) -> SchemaPattern:
+    def deriv(self: Pair, x: str, ctype: ContentType) -> SchemaPattern:
         """Return derivative of the receiver."""
         return Alternative.combine(
             Pair.combine(self.left.deriv(x, ctype), self.right),
             Pair.combine(self.right.deriv(x, ctype), self.left))
 
-    def _eval_when(self, cnode: "InstanceNode") -> None:
+    def _eval_when(self: Pair, cnode: "InstanceNode") -> None:
         self.left._eval_when(cnode)
         self.right._eval_when(cnode)
 
-    def tree(self, indent: int = 0):
+    def tree(self: Pair, indent: int = 0):
         return (" " * indent + "Pair\n" +
                 self.left.tree(indent + 2) + "\n" +
                 self.right.tree(indent + 2))
 
-    def __str__(self) -> str:
+    def __str__(self: Pair) -> str:
         return str(self.left)
 
-    def _mandatory_members(self, ctype: ContentType) -> List[InstanceName]:
+    def _mandatory_members(self: Pair, ctype: ContentType) -> List[InstanceName]:
         return self.left._mandatory_members(ctype) + self.right._mandatory_members(ctype)

--- a/yangson/statement.py
+++ b/yangson/statement.py
@@ -22,6 +22,7 @@ This module implements the following classes:
 * ModuleParser: Recursive-descent parser for YANG modules.
 * Statement: YANG statements.
 """
+from __future__ import annotations
 
 from typing import List, Optional, Tuple
 from .exceptions import (
@@ -38,7 +39,7 @@ class Statement:
     _escape_table = str.maketrans({'"': '\\"', '\\': '\\\\'})
     """Table for translating characters to their escaped form."""
 
-    def __init__(self,
+    def __init__(self: Statement,
                  kw: YangIdentifier,
                  arg: Optional[str],
                  pref: YangIdentifier = None):
@@ -57,7 +58,7 @@ class Statement:
         self.superstmt = None
         self.substatements = []
 
-    def __str__(self) -> str:
+    def __str__(self: Statement) -> str:
         """Return string representation of the receiver.
         """
         kw = (self.keyword if self.prefix is None
@@ -67,7 +68,7 @@ class Statement:
         rest = " { ... }" if self.substatements else ";"
         return kw + arg + rest
 
-    def find1(self, kw: YangIdentifier, arg: str = None,
+    def find1(self: Statement, kw: YangIdentifier, arg: str = None,
               pref: YangIdentifier = None,
               required: bool = False) -> Optional["Statement"]:
         """Return first substatement with the given parameters.
@@ -89,7 +90,7 @@ class Statement:
         if required:
             raise StatementNotFound(str(self), kw)
 
-    def find_all(self, kw: YangIdentifier,
+    def find_all(self: Statement, kw: YangIdentifier,
                  pref: YangIdentifier = None) -> List["Statement"]:
         """Return the list all substatements with the given keyword and prefix.
 
@@ -100,7 +101,7 @@ class Statement:
         return [c for c in self.substatements
                 if c.keyword == kw and c.prefix == pref]
 
-    def get_definition(self, name: YangIdentifier,
+    def get_definition(self: Statement, name: YangIdentifier,
                        kw: YangIdentifier) -> Optional["Statement"]:
         """Search ancestor statements for a definition.
 
@@ -119,7 +120,7 @@ class Statement:
             stmt = stmt.superstmt
         return None
 
-    def get_error_info(self) -> Tuple[Optional[str], Optional[str]]:
+    def get_error_info(self: Statement) -> Tuple[Optional[str], Optional[str]]:
         """Return receiver's error tag and error message if present."""
         etag = self.find1("error-app-tag")
         emsg = self.find1("error-message")
@@ -133,7 +134,7 @@ class ModuleParser(Parser):
                     "\\": "\\"}  # type: Dict[str,str]
     """Dictionary for mapping escape sequences to characters."""
 
-    def __init__(self, text: str, name: YangIdentifier = None, rev: str = None):
+    def __init__(self: ModuleParser, text: str, name: YangIdentifier = None, rev: str = None):
         """Initialize the parser instance.
 
         Args:
@@ -144,7 +145,7 @@ class ModuleParser(Parser):
         self.name = name
         self.rev = rev
 
-    def parse(self) -> Statement:
+    def parse(self: ModuleParser) -> Statement:
         """Parse a complete YANG module or submodule.
 
         Args:
@@ -174,7 +175,7 @@ class ModuleParser(Parser):
             return res
         raise UnexpectedInput(self, "end of input")
 
-    def _back_break(self) -> int:
+    def _back_break(self: ModuleParser) -> int:
         self.offset -= 1
         return -1
 
@@ -193,7 +194,7 @@ class ModuleParser(Parser):
         except KeyError:
             raise InvalidArgument(text) from None
 
-    def opt_separator(self) -> bool:
+    def opt_separator(self: ModuleParser) -> bool:
         """Parse an optional separator and return ``True`` if found.
 
         Raises:
@@ -233,7 +234,7 @@ class ModuleParser(Parser):
             }])
         return start < self.offset
 
-    def separator(self) -> None:
+    def separator(self: ModuleParser) -> None:
         """Parse a mandatory separator.
 
         Raises:
@@ -244,7 +245,7 @@ class ModuleParser(Parser):
         if not present:
             raise UnexpectedInput(self, "separator")
 
-    def keyword(self) -> Tuple[Optional[str], str]:
+    def keyword(self: ModuleParser) -> Tuple[Optional[str], str]:
         """Parse a YANG statement keyword.
 
         Raises:
@@ -258,7 +259,7 @@ class ModuleParser(Parser):
             return (i1, i2)
         return (None, i1)
 
-    def statement(self) -> Statement:
+    def statement(self: ModuleParser) -> Statement:
         """Parse YANG statement.
 
         Raises:
@@ -288,7 +289,7 @@ class ModuleParser(Parser):
                 sub.superstmt = res
         return res
 
-    def argument(self) -> bool:
+    def argument(self: ModuleParser) -> bool:
         """Parse statement argument.
 
         Return ``True`` if the argument is followed by block of substatements.
@@ -319,7 +320,7 @@ class ModuleParser(Parser):
             raise UnexpectedInput(self, "';', '{'" +
                                   (" or '+'" if quoted else ""))
 
-    def sq_argument(self) -> str:
+    def sq_argument(self: ModuleParser) -> str:
         """Parse single-quoted argument.
 
         Raises:
@@ -328,7 +329,7 @@ class ModuleParser(Parser):
         self.offset += 1
         self._arg += self.up_to("'")
 
-    def dq_argument(self) -> str:
+    def dq_argument(self: ModuleParser) -> str:
         """Parse double-quoted argument.
 
         Raises:
@@ -353,7 +354,7 @@ class ModuleParser(Parser):
                       if self._escape else self.input[start:self.offset])
         self.offset += 1
 
-    def unq_argument(self) -> str:
+    def unq_argument(self: ModuleParser) -> str:
         """Parse unquoted argument.
 
         Raises:
@@ -378,7 +379,7 @@ class ModuleParser(Parser):
             }])
         self._arg = self.input[start:self.offset]
 
-    def substatements(self) -> List[Statement]:
+    def substatements(self: ModuleParser) -> List[Statement]:
         """Parse substatements.
 
         Raises:

--- a/yangson/xmlparser.py
+++ b/yangson/xmlparser.py
@@ -18,6 +18,8 @@
 """Extended XML parser that preserves the xmlns attributes
 """
 
+from __future__ import annotations
+
 import xml.etree.ElementTree as ET
 
 
@@ -26,7 +28,7 @@ class XMLParser(ET.XMLPullParser):
     Extended XML parser that add namespaces to ELements as
     xmlns/xmlns:... attributes
     '''
-    def __init__(self, source: str = None):
+    def __init__(self: XMLParser, source: str = None):
         '''
         Initialize the XML parser
 
@@ -43,7 +45,7 @@ class XMLParser(ET.XMLPullParser):
             self.close()
             self.parse()
 
-    def parse(self):
+    def parse(self: XMLParser):
         '''Parse all events in current available data'''
         for ev_type, ev_data in self.read_events():
             if ev_type == 'start-ns':
@@ -60,7 +62,7 @@ class XMLParser(ET.XMLPullParser):
                     ev_data.attrib[attr] = ns_url
 
     @property
-    def root(self):
+    def root(self: XMLParser):
         '''Return root node
 
         Only valid if the first event has been parsed'''

--- a/yangson/xpathast.py
+++ b/yangson/xpathast.py
@@ -23,6 +23,7 @@ class is intended to be public:
 
 * Expr: XPath 1.0 expression with YANG 1.1 extensions.
 """
+from __future__ import annotations
 
 import decimal
 from math import ceil, copysign, floor
@@ -41,14 +42,14 @@ from .typealiases import QualName
 
 class XPathContext:
 
-    def __init__(self, cnode: InstanceNode, origin: InstanceNode,
+    def __init__(self: XPathContext, cnode: InstanceNode, origin: InstanceNode,
                  position: int, size: int):
         self.cnode = cnode
         self.origin = origin
         self.position = position
         self.size = size
 
-    def update_cnode(self, new_cnode: InstanceNode) -> "XPathContext":
+    def update_cnode(self: XPathContext, new_cnode: InstanceNode) -> "XPathContext":
         return self.__class__(new_cnode, self.origin, self.position, self.size)
 
 
@@ -58,11 +59,11 @@ class Expr:
     indent = 2
     _precedence = 8
 
-    def __str__(self) -> str:
+    def __str__(self: Expr) -> str:
         """Return a string representation of the receiver."""
         raise NotImplementedError
 
-    def evaluate(self, node: InstanceNode) -> XPathValue:
+    def evaluate(self: Expr, node: InstanceNode) -> XPathValue:
         """Evaluate the receiver and return the result.
 
         Args:
@@ -74,14 +75,14 @@ class Expr:
         """
         return self._eval(XPathContext(node, node, 1, 1))
 
-    def _eval_float(self, xctx: XPathContext) -> float:
+    def _eval_float(self: Expr, xctx: XPathContext) -> float:
         val = self._eval(xctx)
         try:
             return float(val)
         except ValueError:
             return float('nan')
 
-    def _eval_string(self, xctx: XPathContext) -> str:
+    def _eval_string(self: Expr, xctx: XPathContext) -> str:
         val = self._eval(xctx)
         if isinstance(val, float):
             try:
@@ -95,7 +96,7 @@ class Expr:
             return str(val).lower()
         return str(val)
 
-    def _xfunc_name(self) -> str:
+    def _xfunc_name(self: Expr) -> str:
         """Return XPath function name based on the class.
 
         To be used only for functions.
@@ -105,7 +106,7 @@ class Expr:
             [(c if c.islower() else f"-{c.lower()}") for
              c in fn[1:]])
 
-    def syntax_tree(self, indent: int = 0) -> str:
+    def syntax_tree(self: Expr, indent: int = 0) -> str:
         """Print abstract syntax tree of the receiver."""
         node_name = self.__class__.__name__
         attr = self._properties_str()
@@ -113,17 +114,17 @@ class Expr:
         return (" " * indent + node_name + attr_str +
                 self._children_ast(indent + self.indent))
 
-    def as_instance_route(self) -> InstanceRoute:
+    def as_instance_route(self: Expr) -> InstanceRoute:
         """Convert receiver to an InstanceRoute."""
         raise NotImplementedError
 
-    def _properties_str(self) -> str:
+    def _properties_str(self: Expr) -> str:
         return ""
 
-    def _children_ast(self, indent) -> str:
+    def _children_ast(self: Expr, indent) -> str:
         return ""
 
-    def _predicates_str(self, indent) -> str:
+    def _predicates_str(self: Expr, indent) -> str:
         if not self.predicates:
             return ""
         res = " " * indent + "-- Predicates:\n"
@@ -132,7 +133,7 @@ class Expr:
             res += p.syntax_tree(newi)
         return res
 
-    def _apply_predicates(self, ns: XPathValue,
+    def _apply_predicates(self: Expr, ns: XPathValue,
                           xctx: XPathContext) -> XPathValue:
         for p in self.predicates:
             res = NodeSet([])
@@ -154,47 +155,47 @@ class Expr:
 class UnaryExpr(Expr):
     """Abstract superclass for unary expressions."""
 
-    def __init__(self, expr: Optional[Expr]):
+    def __init__(self: UnaryExpr, expr: Optional[Expr]):
         self.expr = expr
 
-    def __str__(self) -> str:
+    def __str__(self: UnaryExpr) -> str:
         """Return string representation of a unary function.
 
         Non-function subclasses should override this method.
         """
         return f"{self._xfunc_name()}({self.expr if self.expr else ''})"
 
-    def _children_ast(self, indent: int) -> str:
+    def _children_ast(self: UnaryExpr, indent: int) -> str:
         return self.expr.syntax_tree(indent) if self.expr else ""
 
 
 class BinaryExpr(Expr):
     """Abstract superclass of binary expressions."""
 
-    def __init__(self, left: Expr, right: Expr):
+    def __init__(self: BinaryExpr, left: Expr, right: Expr):
         self.left = left
         self.right = right
 
-    def __str__(self) -> str:
+    def __str__(self: BinaryExpr) -> str:
         """Return string representation of a binary function.
 
         Non-function subclasses should override this method.
         """
         return f"{self._xfunc_name()}({self.left}, {self.right})"
 
-    def _children_ast(self, indent: int) -> str:
+    def _children_ast(self: BinaryExpr, indent: int) -> str:
         return self.left.syntax_tree(indent) + self.right.syntax_tree(indent)
 
-    def _eval_ops(self, xctx: XPathContext) -> Tuple[XPathValue, XPathValue]:
+    def _eval_ops(self: BinaryExpr, xctx: XPathContext) -> Tuple[XPathValue, XPathValue]:
         return (self.left._eval(xctx), self.right._eval(xctx))
 
-    def _eval_ops_float(self, xctx: XPathContext) -> Tuple[float, float]:
+    def _eval_ops_float(self: BinaryExpr, xctx: XPathContext) -> Tuple[float, float]:
         return (self.left._eval_float(xctx), self.right._eval_float(xctx))
 
-    def _eval_ops_string(self, xctx: XPathContext) -> Tuple[str, str]:
+    def _eval_ops_string(self: BinaryExpr, xctx: XPathContext) -> Tuple[str, str]:
         return (self.left._eval_string(xctx), self.right._eval_string(xctx))
 
-    def _as_str(self, op: str, spaces=True) -> str:
+    def _as_str(self: BinaryExpr, op: str, spaces=True) -> str:
         lft = str(self.left)
         if self.left._precedence < self._precedence:
             lft = "(" + lft + ")"
@@ -209,10 +210,10 @@ class OrExpr(BinaryExpr):
 
     _precedence = 0
 
-    def __str__(self) -> str:
+    def __str__(self: OrExpr) -> str:
         return self._as_str("or")
 
-    def _eval(self, xctx: XPathContext) -> bool:
+    def _eval(self: OrExpr, xctx: XPathContext) -> bool:
         lres, rres = self._eval_ops(xctx)
         return lres or rres
 
@@ -221,10 +222,10 @@ class AndExpr(BinaryExpr):
 
     _precedence = 1
 
-    def __str__(self) -> str:
+    def __str__(self: AndExpr) -> str:
         return self._as_str("and")
 
-    def _eval(self, xctx: XPathContext) -> bool:
+    def _eval(self: AndExpr, xctx: XPathContext) -> bool:
         lres, rres = self._eval_ops(xctx)
         return lres and rres
 
@@ -233,20 +234,20 @@ class EqualityExpr(BinaryExpr):
 
     _precedence = 2
 
-    def __init__(self, left: Expr, right: Expr, negate: bool):
+    def __init__(self: EqualityExpr, left: Expr, right: Expr, negate: bool):
         super().__init__(left, right)
         self.negate = negate
 
-    def __str__(self) -> str:
+    def __str__(self: EqualityExpr) -> str:
         return self._as_str("!=" if self.negate else "=")
 
-    def as_instance_route(self) -> InstanceRoute:
+    def as_instance_route(self: EqualityExpr) -> InstanceRoute:
         step = self.left
  
-    def _properties_str(self) -> str:
+    def _properties_str(self: EqualityExpr) -> str:
         return "!=" if self.negate else "="
 
-    def _eval(self, xctx: XPathContext) -> bool:
+    def _eval(self: EqualityExpr, xctx: XPathContext) -> bool:
         lres, rres = self._eval_ops(xctx)
         return lres != rres if self.negate else lres == rres
 
@@ -255,23 +256,23 @@ class RelationalExpr(BinaryExpr):
 
     _precedence = 3
 
-    def __init__(self, left: Expr, right: Expr, less: bool,
+    def __init__(self: RelationalExpr, left: Expr, right: Expr, less: bool,
                  equal: bool):
         super().__init__(left, right)
         self.less = less
         self.equal = equal
 
-    def __str__(self) -> str:
+    def __str__(self: RelationalExpr) -> str:
         lg = "<" if self.less else ">"
         return self._as_str(lg + "=" if self.equal else lg)
 
-    def _properties_str(self) -> str:
+    def _properties_str(self: RelationalExpr) -> str:
         res = "<" if self.less else ">"
         if self.equal:
             res += "="
         return res
 
-    def _eval(self, xctx: XPathContext) -> bool:
+    def _eval(self: RelationalExpr, xctx: XPathContext) -> bool:
         lres, rres = self._eval_ops(xctx)
         if self.less:
             return lres <= rres if self.equal else lres < rres
@@ -282,17 +283,17 @@ class AdditiveExpr(BinaryExpr):
 
     _precedence = 4
 
-    def __init__(self, left: Expr, right: Expr, plus: bool):
+    def __init__(self: AdditiveExpr, left: Expr, right: Expr, plus: bool):
         super().__init__(left, right)
         self.plus = plus
 
-    def __str__(self) -> str:
+    def __str__(self: AdditiveExpr) -> str:
         return self._as_str("+" if self.plus else "-")
 
-    def _properties_str(self) -> str:
+    def _properties_str(self: AdditiveExpr) -> str:
         return "+" if self.plus else "-"
 
-    def _eval(self, xctx: XPathContext) -> float:
+    def _eval(self: AdditiveExpr, xctx: XPathContext) -> float:
         lres, rres = self._eval_ops_float(xctx)
         return lres + rres if self.plus else lres - rres
 
@@ -301,15 +302,15 @@ class MultiplicativeExpr(BinaryExpr):
 
     _precedence = 5
 
-    def __init__(self, left: Expr, right: Expr,
+    def __init__(self: MultiplicativeExpr, left: Expr, right: Expr,
                  operator: MultiplicativeOp):
         super().__init__(left, right)
         self.operator = operator
 
-    def __str__(self) -> str:
+    def __str__(self: MultiplicativeExpr) -> str:
         return self._as_str(str(self.operator))
 
-    def _properties_str(self) -> str:
+    def _properties_str(self: MultiplicativeExpr) -> str:
         if self.operator == MultiplicativeOp.multiply:
             return "*"
         if self.operator == MultiplicativeOp.divide:
@@ -317,7 +318,7 @@ class MultiplicativeExpr(BinaryExpr):
         if self.operator == MultiplicativeOp.modulo:
             return "mod"
 
-    def _eval(self, xctx: XPathContext) -> float:
+    def _eval(self: MultiplicativeExpr, xctx: XPathContext) -> float:
         lres, rres = self._eval_ops_float(xctx)
         if self.operator == MultiplicativeOp.multiply:
             return lres * rres
@@ -337,17 +338,17 @@ class UnaryMinusExpr(UnaryExpr):
 
     _precedence = 6
 
-    def __init__(self, expr: Expr, negate: bool):
+    def __init__(self: UnaryMinusExpr, expr: Expr, negate: bool):
         super().__init__(expr)
         self.negate = negate
 
-    def __str__(self) -> str:
+    def __str__(self: UnaryMinusExpr) -> str:
         return f"{'-' if self.negate else ''}{self.expr}"
 
-    def _properties_str(self) -> str:
+    def _properties_str(self: UnaryMinusExpr) -> str:
         return "-" if self.negate else "+"
 
-    def _eval(self, xctx: XPathContext) -> float:
+    def _eval(self: UnaryMinusExpr, xctx: XPathContext) -> float:
         res = self.expr._eval_float(xctx)
         return -res if self.negate else res
 
@@ -356,50 +357,50 @@ class UnionExpr(BinaryExpr):
 
     _precedence = 7
 
-    def __str__(self) -> str:
+    def __str__(self: UnionExpr) -> str:
         return self._as_str("|")
 
-    def _eval(self, xctx: XPathContext) -> NodeSet:
+    def _eval(self: UnionExpr, xctx: XPathContext) -> NodeSet:
         lres, rres = self._eval_ops(xctx)
         return lres.union(rres)
 
 
 class Literal(Expr):
 
-    def __init__(self, value: str):
+    def __init__(self: Literal, value: str):
         self.value = value
 
-    def __str__(self) -> str:
+    def __str__(self: Literal) -> str:
         return quoteattr(self.value)
 
-    def _properties_str(self) -> str:
+    def _properties_str(self: Literal) -> str:
         return self.value
 
-    def _eval(self, xctx: XPathContext) -> str:
+    def _eval(self: Literal, xctx: XPathContext) -> str:
         return self.value
 
 
 class Number(Expr):
 
-    def __init__(self, value: float):
+    def __init__(self: Number, value: float):
         self.value = value
 
-    def __str__(self) -> str:
+    def __str__(self: Number) -> str:
         return str(self.value)
 
-    def _properties_str(self) -> str:
+    def _properties_str(self: Number) -> str:
         return str(self.value)
 
-    def _eval(self, xctx: XPathContext) -> float:
+    def _eval(self: Number, xctx: XPathContext) -> float:
         return float(self.value)
 
 
 class PathExpr(BinaryExpr):
 
-    def __str__(self) -> str:
+    def __str__(self: PathExpr) -> str:
         return self._as_str("/", spaces=False)
 
-    def _eval(self, xctx: XPathContext) -> XPathValue:
+    def _eval(self: PathExpr, xctx: XPathContext) -> XPathValue:
         ns = self.left._eval(xctx)
         if not isinstance(ns, NodeSet):
             raise XPathTypeError(str(ns))
@@ -411,34 +412,34 @@ class PathExpr(BinaryExpr):
 
 class FilterExpr(Expr):
 
-    def __init__(self, primary: Expr, predicates: List[Expr]):
+    def __init__(self: FilterExpr, primary: Expr, predicates: List[Expr]):
         self.primary = primary
         self.predicates = predicates
 
-    def __str__(self) -> str:
+    def __str__(self: FilterExpr) -> str:
         return (str(self.primary) +
                 "".join([f"[{p}]" for p in self.predicates]))
 
-    def _children_ast(self, indent) -> str:
+    def _children_ast(self: FilterExpr, indent) -> str:
         return self.primary.syntax_tree(indent) + self._predicates_str(indent)
 
-    def _eval(self, xctx: XPathContext) -> XPathValue:
+    def _eval(self: FilterExpr, xctx: XPathContext) -> XPathValue:
         res = self.primary._eval(xctx)
         return self._apply_predicates(res, xctx)
 
 
 class LocationPath(BinaryExpr):
 
-    def _eval(self, xctx: XPathContext) -> XPathValue:
+    def _eval(self: LocationPath, xctx: XPathContext) -> XPathValue:
         lres = self.left._eval(xctx)
         ns = lres.bind(self.right._node_trans(xctx))
         return self.right._apply_predicates(ns, xctx)
 
-    def __str__(self) -> str:
+    def __str__(self: LocationPath) -> str:
         sep = "" if isinstance(self.left, Root) else "/"
         return f"{self.left}{sep}{self.right}"
 
-    def as_instance_route(self) -> InstanceRoute:
+    def as_instance_route(self: LocationPath) -> InstanceRoute:
         return InstanceRoute(self.left.as_instance_route() +
                              self.right.as_instance_route())
    
@@ -447,25 +448,25 @@ class Root(Expr):
 
     _precedence = 8
 
-    def _eval(self, xctx: XPathContext) -> NodeSet:
+    def _eval(self: Root, xctx: XPathContext) -> NodeSet:
         return NodeSet([xctx.cnode.top()])
 
-    def __str__(self) -> str:
+    def __str__(self: Root) -> str:
         return "/"
 
-    def as_instance_route(self) -> InstanceRoute:
+    def as_instance_route(self: Root) -> InstanceRoute:
         return InstanceRoute([])
 
 
 class Step(Expr):
 
-    def __init__(self, axis: Axis, qname: QualName,
+    def __init__(self: Step, axis: Axis, qname: QualName,
                  predicates: List[Expr]):
         self.axis = axis
         self.qname = qname
         self.predicates = predicates
 
-    def __str__(self) -> str:
+    def __str__(self: Step) -> str:
         if self.axis == Axis.descendant_or_self and self.qname is None:
             return ""
         if self.axis == Axis.self and self.qname is None:
@@ -482,7 +483,7 @@ class Step(Expr):
         prs = "".join([f"[{p}]" for p in self.predicates])
         return ax + qn + prs
 
-    def as_instance_route(self) -> InstanceRoute:
+    def as_instance_route(self: Step) -> InstanceRoute:
         m = MemberName(*self.qname)
         if not(self.predicates): return InstanceRoute([m])
         p0 = self.predicates[0]
@@ -495,13 +496,13 @@ class Step(Expr):
             espec = EntryKeys(ks)
         return InstanceRoute([m, espec]) 
     
-    def _properties_str(self) -> str:
+    def _properties_str(self: Step) -> str:
         return f"{self.axis.name} {self.qname}"
 
-    def _children_ast(self, indent) -> str:
+    def _children_ast(self: Step, indent) -> str:
         return self._predicates_str(indent)
 
-    def _node_trans(self, xctx) -> NodeExpr:
+    def _node_trans(self: Step, xctx) -> NodeExpr:
         return {
             Axis.ancestor: lambda n, qn=self.qname: n._ancestors(qn),
             Axis.ancestor_or_self:
@@ -522,14 +523,14 @@ class Step(Expr):
                 else [n],
         }[self.axis]
 
-    def _eval(self, xctx: XPathContext) -> XPathValue:
+    def _eval(self: Step, xctx: XPathContext) -> XPathValue:
         ns = NodeSet(self._node_trans(xctx)(xctx.cnode))
         return self._apply_predicates(ns, xctx)
 
 
 class FuncBitIsSet(BinaryExpr):
 
-    def _eval(self, xctx: XPathContext) -> bool:
+    def _eval(self: FuncBitIsSet, xctx: XPathContext) -> bool:
         ns = self.left._eval(xctx)
         if not isinstance(ns, NodeSet):
             raise XPathTypeError(str(ns))
@@ -542,57 +543,57 @@ class FuncBitIsSet(BinaryExpr):
 
 class FuncBoolean(UnaryExpr):
 
-    def _eval(self, xctx: XPathContext) -> bool:
+    def _eval(self: FuncBoolean, xctx: XPathContext) -> bool:
         return bool(self.expr._eval(xctx))
 
 
 class FuncCeiling(UnaryExpr):
 
-    def _eval(self, xctx: XPathContext) -> float:
+    def _eval(self: FuncCeiling, xctx: XPathContext) -> float:
         return float(ceil(self.expr._eval_float(xctx)))
 
 
 class FuncConcat(Expr):
 
-    def __init__(self, parts: List[Expr]):
+    def __init__(self: FuncConcat, parts: List[Expr]):
         self.parts = parts
 
-    def __str__(self) -> str:
+    def __str__(self: FuncConcat) -> str:
         return f"concat({', '.join([str(p) for p in self.parts])})"
 
-    def _children_ast(self, indent: int) -> str:
+    def _children_ast(self: FuncConcat, indent: int) -> str:
         return "".join([ex.syntax_tree(indent) for ex in self.parts])
 
-    def _eval(self, xctx: XPathContext) -> str:
+    def _eval(self: FuncConcat, xctx: XPathContext) -> str:
         return "".join([ex._eval_string(xctx) for ex in self.parts])
 
 
 class FuncContains(BinaryExpr):
 
-    def _eval(self, xctx: XPathContext) -> bool:
+    def _eval(self: FuncContains, xctx: XPathContext) -> bool:
         lres, rres = self._eval_ops_string(xctx)
         return lres.find(rres) >= 0
 
 
 class FuncCount(UnaryExpr):
 
-    def _eval(self, xctx: XPathContext) -> int:
+    def _eval(self: FuncCount, xctx: XPathContext) -> int:
         ns = self.expr._eval(xctx)
         return float(len(ns))
 
 
 class FuncCurrent(Expr):
 
-    def _eval(self, xctx: XPathContext) -> NodeSet:
+    def _eval(self: FuncCurrent, xctx: XPathContext) -> NodeSet:
         return NodeSet([xctx.origin])
 
-    def __str__(self) -> str:
+    def __str__(self: FuncCurrent) -> str:
         return "current()"
 
 
 class FuncDeref(UnaryExpr):
 
-    def _eval(self, xctx: XPathContext) -> NodeSet:
+    def _eval(self: FuncDeref, xctx: XPathContext) -> NodeSet:
         ns = self.expr._eval(xctx)
         if not isinstance(ns, NodeSet):
             raise XPathTypeError(str(ns))
@@ -602,20 +603,20 @@ class FuncDeref(UnaryExpr):
 
 class FuncDerivedFrom(BinaryExpr):
 
-    def __init__(self, left: Expr, right: Expr, or_self: bool,
+    def __init__(self: FuncDerivedFrom, left: Expr, right: Expr, or_self: bool,
                  sctx: SchemaContext):
         super().__init__(left, right)
         self.or_self = or_self
         self.sctx = sctx
 
-    def _xfunc_name(self) -> str:
+    def _xfunc_name(self: FuncDerivedFrom) -> str:
         return ("derived-from-or-self" if self.or_self else "derived-from")
 
-    def _properties_str(self) -> str:
+    def _properties_str(self: FuncDerivedFrom) -> str:
         return ("OR-SELF, " if self.or_self
                 else "") + self.sctx.schema_data.namespace(self.mid)
 
-    def _eval(self, xctx: XPathContext) -> bool:
+    def _eval(self: FuncDerivedFrom, xctx: XPathContext) -> bool:
         ns = self.left._eval(xctx)
         if not isinstance(ns, NodeSet):
             raise XPathTypeError(str(ns))
@@ -633,7 +634,7 @@ class FuncDerivedFrom(BinaryExpr):
 
 class FuncEnumValue(UnaryExpr):
 
-    def _eval(self, xctx: XPathContext) -> float:
+    def _eval(self: FuncEnumValue, xctx: XPathContext) -> float:
         ns = self.expr._eval(xctx)
         if not isinstance(ns, NodeSet):
             raise XPathTypeError(str(ns))
@@ -646,42 +647,42 @@ class FuncEnumValue(UnaryExpr):
 
 class FuncFalse(Expr):
 
-    def __str__(self) -> str:
+    def __str__(self: FuncFalse) -> str:
         return "false()"
 
-    def _eval(self, xctx: XPathContext) -> bool:
+    def _eval(self: FuncFalse, xctx: XPathContext) -> bool:
         return False
 
 
 class FuncFloor(UnaryExpr):
 
-    def _eval(self, xctx: XPathContext) -> float:
+    def _eval(self: FuncFloor, xctx: XPathContext) -> float:
         return float(floor(self.expr._eval_float(xctx)))
 
 
 class FuncLast(Expr):
 
-    def __str__(self) -> str:
+    def __str__(self: FuncLast) -> str:
         return "last()"
 
-    def _eval(self, xctx: XPathContext) -> int:
+    def _eval(self: FuncLast, xctx: XPathContext) -> int:
         return float(xctx.size)
 
 
 class FuncName(UnaryExpr):
 
-    def __init__(self, expr: Optional[Expr], local: bool):
+    def __init__(self: FuncName, expr: Optional[Expr], local: bool):
         super().__init__(expr)
         self.local = local
 
-    def __str__(self) -> str:
+    def __str__(self: FuncName) -> str:
         fn = "local-name" if self.local else "name"
         return f"{fn}({self.expr if self.expr else ''})"
 
-    def _properties_str(self) -> str:
+    def _properties_str(self: FuncName) -> str:
         return "LOCAL" if self.local else ""
 
-    def _eval(self, xctx: XPathContext) -> str:
+    def _eval(self: FuncName, xctx: XPathContext) -> str:
         if self.expr is None:
             node = xctx.cnode
         else:
@@ -702,20 +703,20 @@ class FuncName(UnaryExpr):
 
 class FuncNormalizeSpace(UnaryExpr):
 
-    def _eval(self, xctx: XPathContext) -> str:
+    def _eval(self: FuncNormalizeSpace, xctx: XPathContext) -> str:
         string = self.expr._eval_string(xctx) if self.expr else str(xctx.cnode)
         return " ".join(string.strip().split())
 
 
 class FuncNot(UnaryExpr):
 
-    def _eval(self, xctx: XPathContext) -> bool:
+    def _eval(self: FuncNot, xctx: XPathContext) -> bool:
         return not(self.expr._eval(xctx))
 
 
 class FuncNumber(UnaryExpr):
 
-    def _eval(self, xctx: XPathContext) -> float:
+    def _eval(self: FuncNumber, xctx: XPathContext) -> float:
         if self.expr is None:
             try:
                 return float(xctx.cnode.value)
@@ -726,16 +727,16 @@ class FuncNumber(UnaryExpr):
 
 class FuncPosition(Expr):
 
-    def __str__(self) -> str:
+    def __str__(self: FuncPosition) -> str:
         return "position()"
 
-    def _eval(self, xctx: XPathContext) -> int:
+    def _eval(self: FuncPosition, xctx: XPathContext) -> int:
         return xctx.position
 
 
 class FuncReMatch(BinaryExpr):
 
-    def _eval(self, xctx: XPathContext) -> bool:
+    def _eval(self: FuncReMatch, xctx: XPathContext) -> bool:
         lres, rres = self._eval_ops_string(xctx)
         try:
             return re.match(XMLToPython(rres), lres) is not None
@@ -745,7 +746,7 @@ class FuncReMatch(BinaryExpr):
 
 class FuncRound(UnaryExpr):
 
-    def _eval(self, xctx: XPathContext) -> float:
+    def _eval(self: FuncRound, xctx: XPathContext) -> float:
         dec = decimal.Decimal(self.expr._eval_float(xctx))
         try:
             return float(dec.to_integral_value(
@@ -756,14 +757,14 @@ class FuncRound(UnaryExpr):
 
 class FuncStartsWith(BinaryExpr):
 
-    def _eval(self, xctx: XPathContext) -> bool:
+    def _eval(self: FuncStartsWith, xctx: XPathContext) -> bool:
         lres, rres = self._eval_ops_string(xctx)
         return lres.startswith(rres)
 
 
 class FuncString(UnaryExpr):
 
-    def _eval(self, xctx: XPathContext) -> str:
+    def _eval(self: FuncString, xctx: XPathContext) -> str:
         if self.expr is None:
             return str(xctx.cnode)
         return self.expr._eval_string(xctx)
@@ -771,28 +772,28 @@ class FuncString(UnaryExpr):
 
 class FuncStringLength(UnaryExpr):
 
-    def _eval(self, xctx: XPathContext) -> str:
+    def _eval(self: FuncStringLength, xctx: XPathContext) -> str:
         string = self.expr._eval_string(xctx) if self.expr else str(xctx.cnode)
         return float(len(string))
 
 
 class FuncSubstring(BinaryExpr):
 
-    def __init__(self, string: Expr, start: Expr,
+    def __init__(self: FuncSubstring, string: Expr, start: Expr,
                  length: Optional[Expr]):
         super().__init__(string, start)
         self.length = length
 
-    def __str__(self) -> str:
+    def __str__(self: FuncSubstring) -> str:
         res = f"{self._xfunc_name()}({self.left}, {self.right}"
         if self.length:
             res += f", {self.length}"
         return res + ")"
 
-    def _children_ast(self, indent: int) -> str:
+    def _children_ast(self: FuncSubstring, indent: int) -> str:
         return super()._children_ast(indent) + self.length.syntax_tree(indent)
 
-    def _eval(self, xctx: XPathContext) -> str:
+    def _eval(self: FuncSubstring, xctx: XPathContext) -> str:
         string = self.left._eval_string(xctx)
         rres = self.right._eval_float(xctx)
         try:
@@ -811,7 +812,7 @@ class FuncSubstring(BinaryExpr):
 
 class FuncSubstringAfter(BinaryExpr):
 
-    def _eval(self, xctx: XPathContext) -> str:
+    def _eval(self: FuncSubstringAfter, xctx: XPathContext) -> str:
         lres, rres = self._eval_ops_string(xctx)
         ind = lres.find(rres)
         return lres[ind + len(rres):] if ind >= 0 else ""
@@ -819,7 +820,7 @@ class FuncSubstringAfter(BinaryExpr):
 
 class FuncSubstringBefore(BinaryExpr):
 
-    def _eval(self, xctx: XPathContext) -> str:
+    def _eval(self: FuncSubstringBefore, xctx: XPathContext) -> str:
         lres, rres = self._eval_ops_string(xctx)
         ind = lres.find(rres)
         return lres[:ind] if ind >= 0 else ""
@@ -827,7 +828,7 @@ class FuncSubstringBefore(BinaryExpr):
 
 class FuncSum(UnaryExpr):
 
-    def _eval(self, xctx: XPathContext) -> float:
+    def _eval(self: FuncSum, xctx: XPathContext) -> float:
         ns = self.expr._eval(xctx)
         if not isinstance(ns, NodeSet):
             raise XPathTypeError(str(ns))
@@ -839,17 +840,17 @@ class FuncSum(UnaryExpr):
 
 class FuncTranslate(BinaryExpr):
 
-    def __init__(self, s1: Expr, s2: Expr, s3: Expr):
+    def __init__(self: FuncTranslate, s1: Expr, s2: Expr, s3: Expr):
         super().__init__(s1, s2)
         self.nchars = s3
 
-    def __str__(self) -> str:
+    def __str__(self: FuncTranslate) -> str:
         return f"{self._xfunc_name()}({self.left}, {self.right}, {self.nchars})"
 
-    def _children_ast(self, indent: int) -> str:
+    def _children_ast(self: FuncTranslate, indent: int) -> str:
         return super()._children_ast(indent) + self.nchars.syntax_tree(indent)
 
-    def _eval(self, xctx: XPathContext) -> str:
+    def _eval(self: FuncTranslate, xctx: XPathContext) -> str:
         string, old = self._eval_ops_string(xctx)
         new = self.nchars._eval_string(xctx)[:len(old)]
         ttab = str.maketrans(old[:len(new)], new, old[len(new):])
@@ -858,8 +859,8 @@ class FuncTranslate(BinaryExpr):
 
 class FuncTrue(Expr):
 
-    def __str__(self) -> str:
+    def __str__(self: FuncTrue) -> str:
         return "true()"
 
-    def _eval(self, xctx: XPathContext) -> bool:
+    def _eval(self: FuncTrue, xctx: XPathContext) -> bool:
         return True

--- a/yangson/xpathparser.py
+++ b/yangson/xpathparser.py
@@ -24,6 +24,7 @@ This module defines the following classes:
 The module also defines the following exceptions:
 
 """
+from __future__ import annotations
 
 from typing import List, Optional, Tuple, Union
 from .schemadata import SchemaContext
@@ -45,7 +46,7 @@ from .xpathast import (
 class XPathParser(Parser):
     """Parser for XPath expressions."""
 
-    def __init__(self, text: str, sctx: SchemaContext):
+    def __init__(self: XPathParser, text: str, sctx: SchemaContext):
         """Initialize the parser instance.
 
         Args:
@@ -54,7 +55,7 @@ class XPathParser(Parser):
         super().__init__(text)
         self.sctx = sctx
 
-    def parse(self) -> Expr:
+    def parse(self: XPathParser) -> Expr:
         """Parse an XPath expression.
 
         Returns:
@@ -68,7 +69,7 @@ class XPathParser(Parser):
         self.skip_ws()
         return self._or_expr()
 
-    def _or_expr(self) -> Expr:
+    def _or_expr(self: XPathParser) -> Expr:
         op1 = self._and_expr()
         while self.test_string("or"):
             self.skip_ws()
@@ -76,7 +77,7 @@ class XPathParser(Parser):
             op1 = OrExpr(op1, op2)
         return op1
 
-    def _and_expr(self) -> Expr:
+    def _and_expr(self: XPathParser) -> Expr:
         op1 = self._equality_expr()
         while self.test_string("and"):
             self.skip_ws()
@@ -84,7 +85,7 @@ class XPathParser(Parser):
             op1 = AndExpr(op1, op2)
         return op1
 
-    def _equality_expr(self) -> Expr:
+    def _equality_expr(self: XPathParser) -> Expr:
         op1 = self._relational_expr()
         while True:
             negate = False
@@ -107,7 +108,7 @@ class XPathParser(Parser):
             op2 = self._relational_expr()
             op1 = EqualityExpr(op1, op2, negate)
 
-    def _relational_expr(self) -> Expr:
+    def _relational_expr(self: XPathParser) -> Expr:
         op1 = self._additive_expr()
         while True:
             try:
@@ -122,7 +123,7 @@ class XPathParser(Parser):
             op2 = self._additive_expr()
             op1 = RelationalExpr(op1, op2, rel == "<", eq)
 
-    def _additive_expr(self) -> Expr:
+    def _additive_expr(self: XPathParser) -> Expr:
         op1 = self._multiplicative_expr()
         while True:
             try:
@@ -135,7 +136,7 @@ class XPathParser(Parser):
             op2 = self._multiplicative_expr()
             op1 = AdditiveExpr(op1, op2, pm == "+")
 
-    def _multiplicative_expr(self) -> Expr:
+    def _multiplicative_expr(self: XPathParser) -> Expr:
         op1 = self._unary_minus_expr()
         while True:
             if self.test_string("*"):
@@ -150,7 +151,7 @@ class XPathParser(Parser):
             op2 = self._unary_minus_expr()
             op1 = MultiplicativeExpr(op1, op2, mulop)
 
-    def _unary_minus_expr(self) -> Expr:
+    def _unary_minus_expr(self: XPathParser) -> Expr:
         negate = None
         while self.test_string("-"):
             negate = not negate
@@ -158,7 +159,7 @@ class XPathParser(Parser):
         expr = self._union_expr()
         return expr if negate is None else UnaryMinusExpr(expr, negate)
 
-    def _union_expr(self) -> Expr:
+    def _union_expr(self: XPathParser) -> Expr:
         op1 = self._lit_num_path()
         while self.test_string("|"):
             self.skip_ws()
@@ -166,7 +167,7 @@ class XPathParser(Parser):
             op1 = UnionExpr(op1, op2)
         return op1
 
-    def _lit_num_path(self) -> Expr:
+    def _lit_num_path(self: XPathParser) -> Expr:
         next = self.peek()
         if next == "(":
             self.adv_skip_ws()
@@ -195,13 +196,13 @@ class XPathParser(Parser):
         self.offset = start
         return self._location_path()
 
-    def _path_expr(self, fname: str) -> Expr:
+    def _path_expr(self: XPathParser, fname: str) -> Expr:
         fexpr = self._filter_expr(fname)
         if self.test_string("/"):
             return PathExpr(fexpr, self._location_path())
         return fexpr
 
-    def _filter_expr(self, fname: str) -> Expr:
+    def _filter_expr(self: XPathParser, fname: str) -> Expr:
         if fname is None:
             prim = self._or_expr()
         else:
@@ -216,7 +217,7 @@ class XPathParser(Parser):
         self.skip_ws()
         return FilterExpr(prim, self._predicates())
 
-    def _predicates(self) -> List[Expr]:
+    def _predicates(self: XPathParser) -> List[Expr]:
         res = []
         while self.test_string("["):
             self.skip_ws()
@@ -225,10 +226,10 @@ class XPathParser(Parser):
             self.skip_ws()
         return res
 
-    def _predicate(self) -> Expr:
+    def _predicate(self: XPathParser) -> Expr:
         return self._or_expr()
 
-    def _location_path(self) -> LocationPath:
+    def _location_path(self: XPathParser) -> LocationPath:
         if self.test_string("/"):
             self.skip_ws()
             if self.at_end():
@@ -242,10 +243,10 @@ class XPathParser(Parser):
             op1 = LocationPath(op1, op2)
         return op1
 
-    def _step(self) -> Step:
+    def _step(self: XPathParser) -> Step:
         return Step(*self._axis_qname(), self._predicates())
 
-    def _axis_qname(self) -> Tuple[Axis, Union[QualName, bool, None]]:
+    def _axis_qname(self: XPathParser) -> Tuple[Axis, Union[QualName, bool, None]]:
         next = self.peek()
         if next == "*":
             self.adv_skip_ws()
@@ -290,7 +291,7 @@ class XPathParser(Parser):
             return Axis.child, (loc, nsp)
         return Axis.child, (yid, self.sctx.default_ns)
 
-    def _node_type(self, typ):
+    def _node_type(self: XPathParser, typ):
         if typ == "node":
             self.adv_skip_ws()
             self.char(")")
@@ -300,7 +301,7 @@ class XPathParser(Parser):
             raise NotSupported(self, f"node type '{typ}()'")
         raise InvalidXPath(self)
 
-    def _qname(self) -> Optional[QualName]:
+    def _qname(self: XPathParser) -> Optional[QualName]:
         """Parse XML QName."""
         if self.test_string("*"):
             self.skip_ws()
@@ -322,25 +323,25 @@ class XPathParser(Parser):
         self.skip_ws()
         return res
 
-    def _opt_arg(self) -> Optional[Expr]:
+    def _opt_arg(self: XPathParser) -> Optional[Expr]:
         return None if self.peek() == ")" else self.parse()
 
-    def _two_args(self) -> Tuple[Expr, Expr]:
+    def _two_args(self: XPathParser) -> Tuple[Expr, Expr]:
         fst = self.parse()
         self.char(",")
         self.skip_ws()
         return fst, self.parse()
 
-    def _func_bit_is_set(self) -> FuncBitIsSet:
+    def _func_bit_is_set(self: XPathParser) -> FuncBitIsSet:
         return FuncBitIsSet(*self._two_args())
 
-    def _func_boolean(self) -> FuncBoolean:
+    def _func_boolean(self: XPathParser) -> FuncBoolean:
         return FuncBoolean(self.parse())
 
-    def _func_ceiling(self) -> FuncCeiling:
+    def _func_ceiling(self: XPathParser) -> FuncCeiling:
         return FuncCeiling(self.parse())
 
-    def _func_concat(self) -> FuncConcat:
+    def _func_concat(self: XPathParser) -> FuncConcat:
         res = [self.parse()]
         while self.test_string(","):
             self.skip_ws()
@@ -349,70 +350,70 @@ class XPathParser(Parser):
             raise InvalidXPath(self)
         return FuncConcat(res)
 
-    def _func_contains(self) -> FuncContains:
+    def _func_contains(self: XPathParser) -> FuncContains:
         return FuncContains(*self._two_args())
 
-    def _func_count(self) -> FuncCount:
+    def _func_count(self: XPathParser) -> FuncCount:
         return FuncCount(self.parse())
 
-    def _func_current(self) -> FuncCurrent:
+    def _func_current(self: XPathParser) -> FuncCurrent:
         return FuncCurrent()
 
-    def _func_deref(self) -> FuncDeref:
+    def _func_deref(self: XPathParser) -> FuncDeref:
         return FuncDeref(self.parse())
 
-    def _func_derived_from(self) -> FuncDerivedFrom:
+    def _func_derived_from(self: XPathParser) -> FuncDerivedFrom:
         return FuncDerivedFrom(*self._two_args(), False, self.sctx)
 
-    def _func_derived_from_or_self(self) -> FuncDerivedFrom:
+    def _func_derived_from_or_self(self: XPathParser) -> FuncDerivedFrom:
         return FuncDerivedFrom(*self._two_args(), True, self.sctx)
 
-    def _func_enum_value(self) -> FuncEnumValue:
+    def _func_enum_value(self: XPathParser) -> FuncEnumValue:
         return FuncEnumValue(self.parse())
 
-    def _func_false(self) -> FuncFalse:
+    def _func_false(self: XPathParser) -> FuncFalse:
         return FuncFalse()
 
-    def _func_floor(self) -> FuncFloor:
+    def _func_floor(self: XPathParser) -> FuncFloor:
         return FuncFloor(self.parse())
 
-    def _func_last(self) -> FuncLast:
+    def _func_last(self: XPathParser) -> FuncLast:
         return FuncLast()
 
-    def _func_local_name(self) -> FuncName:
+    def _func_local_name(self: XPathParser) -> FuncName:
         return FuncName(self._opt_arg(), local=True)
 
-    def _func_name(self) -> FuncName:
+    def _func_name(self: XPathParser) -> FuncName:
         return FuncName(self._opt_arg(), local=False)
 
-    def _func_normalize_space(self) -> FuncNormalizeSpace:
+    def _func_normalize_space(self: XPathParser) -> FuncNormalizeSpace:
         return FuncNormalizeSpace(self._opt_arg())
 
-    def _func_not(self) -> FuncNot:
+    def _func_not(self: XPathParser) -> FuncNot:
         return FuncNot(self.parse())
 
-    def _func_number(self) -> FuncNumber:
+    def _func_number(self: XPathParser) -> FuncNumber:
         return FuncNumber(self._opt_arg())
 
-    def _func_position(self) -> FuncPosition:
+    def _func_position(self: XPathParser) -> FuncPosition:
         return FuncPosition()
 
-    def _func_re_match(self) -> FuncReMatch:
+    def _func_re_match(self: XPathParser) -> FuncReMatch:
         return FuncReMatch(*self._two_args())
 
-    def _func_round(self) -> FuncRound:
+    def _func_round(self: XPathParser) -> FuncRound:
         return FuncRound(self.parse())
 
-    def _func_starts_with(self) -> FuncStartsWith:
+    def _func_starts_with(self: XPathParser) -> FuncStartsWith:
         return FuncStartsWith(*self._two_args())
 
-    def _func_string(self) -> FuncString:
+    def _func_string(self: XPathParser) -> FuncString:
         return FuncString(self._opt_arg())
 
-    def _func_string_length(self) -> FuncStringLength:
+    def _func_string_length(self: XPathParser) -> FuncStringLength:
         return FuncStringLength(self._opt_arg())
 
-    def _func_substring(self) -> FuncSubstring:
+    def _func_substring(self: XPathParser) -> FuncSubstring:
         string, start = self._two_args()
         if self.test_string(","):
             self.skip_ws()
@@ -421,20 +422,20 @@ class XPathParser(Parser):
             length = None
         return FuncSubstring(string, start, length)
 
-    def _func_substring_after(self) -> FuncSubstringAfter:
+    def _func_substring_after(self: XPathParser) -> FuncSubstringAfter:
         return FuncSubstringAfter(*self._two_args())
 
-    def _func_substring_before(self) -> FuncSubstringBefore:
+    def _func_substring_before(self: XPathParser) -> FuncSubstringBefore:
         return FuncSubstringBefore(*self._two_args())
 
-    def _func_sum(self) -> FuncSum:
+    def _func_sum(self: XPathParser) -> FuncSum:
         return FuncSum(self.parse())
 
-    def _func_translate(self) -> FuncTranslate:
+    def _func_translate(self: XPathParser) -> FuncTranslate:
         s1, s2 = self._two_args()
         self.char(",")
         self.skip_ws()
         return FuncTranslate(s1, s2, self.parse())
 
-    def _func_true(self) -> FuncTrue:
+    def _func_true(self: XPathParser) -> FuncTrue:
         return FuncTrue()


### PR DESCRIPTION
Hi Lada,

WARNING: only works for Python >= 3.7.  Does`Yangson` care about older versions of Python?

1. This may appear to be a large diff, but it is all the same single change applied to each method call.  
2. The change simply modifies the method's signature as follows:
    - OLD: `def foo(self...`
    - NEW: `def foo(self: <classname>...`
3. The change does NOT modify any running code (i.e., annotations are ignored by the compiler)
4. I wrote a script to do the conversion, so as to mitigate the possibility for errors.
5. All tests pass using `pytest`.

Please read the `commit` message for motivation and additional details.
