### PR TITLE
Restore support for python 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name = "yangson",
-    python_requires=">=3.7",
+    python_requires=">=3.6",
     packages = ["yangson"],
     use_scm_version = True,
     setup_requires=["setuptools_scm"],
@@ -45,7 +45,7 @@ Installation
 
     python -m pip install yangson
 
-Note that *Yangson* requires Python 3.7 or higher.
+Note that *Yangson* requires Python 3.6 or higher.
 
 Links
 =====

--- a/yangson/constraint.py
+++ b/yangson/constraint.py
@@ -25,7 +25,6 @@ This module implements the following classes:
 * Must: Class representing the constraint specified by a "must" statement.
 """
 
-from __future__ import annotations
 import decimal
 import re
 from typing import Callable, List, Optional, Union
@@ -45,7 +44,7 @@ Interval = List[Number]
 class Constraint:
     """Abstract class representing annotated YANG constraints."""
 
-    def __init__(self: Constraint, error_tag: Optional[str], error_message: Optional[str]):
+    def __init__(self, error_tag: Optional[str], error_message: Optional[str]):
         """Initialize the class instance."""
         self.error_tag = error_tag
         self.error_message = error_message
@@ -54,7 +53,7 @@ class Constraint:
 class Intervals(Constraint):
     """Class representing a sequence of numeric intervals."""
 
-    def __init__(self: Intervals, intervals: List[Interval],
+    def __init__(self, intervals: List[Interval],
                  parser: Callable[[str], Optional[Number]] = None,
                  error_tag: str = None, error_message: str = None):
         """Initialize the class instance."""
@@ -67,7 +66,7 @@ class Intervals(Constraint):
         self.intervals = intervals
         self.parser = parser if parser else _pint
 
-    def __contains__(self: Intervals, value: Number):
+    def __contains__(self, value: Number):
         """Return ``True`` if the receiver contains the value."""
         for r in self.intervals:
             if len(r) == 1:
@@ -77,12 +76,12 @@ class Intervals(Constraint):
                 return True
         return False
 
-    def __str__(self: Intervals) -> str:
+    def __str__(self) -> str:
         """Return string representation of the receiver."""
         return " | ".join([f"{r[0]!s}..{r[-1]!s}" if len(r) > 1 else str(r[0])
                            for r in self.intervals])
 
-    def restrict_with(self: Intervals, expr: str, error_tag: str = None,
+    def restrict_with(self, expr: str, error_tag: str = None,
                       error_message: str = None) -> None:
         """Combine the receiver with new intervals.
 
@@ -130,7 +129,7 @@ class Intervals(Constraint):
 class Pattern(Constraint):
     """Class representing regular expression pattern."""
 
-    def __init__(self: Pattern, pattern: str, invert_match: bool = False,
+    def __init__(self, pattern: str, invert_match: bool = False,
                  error_tag: str = None,
                  error_message: str = None):
         """Initialize the class instance."""
@@ -147,7 +146,7 @@ class Pattern(Constraint):
 class Must(Constraint):
     """Class representing the constraint specified by a "must" statement."""
 
-    def __init__(self: Must, expression: Expr, error_tag: str = None,
+    def __init__(self, expression: Expr, error_tag: str = None,
                  error_message: str = None):
         """Initialize the class instance."""
         super().__init__(

--- a/yangson/datamodel.py
+++ b/yangson/datamodel.py
@@ -22,7 +22,6 @@ This module implements the following class:
 * DataModel: Basic entry point to the YANG data model.
 """
 
-from __future__ import annotations
 import hashlib
 import json
 from typing import Optional, Tuple
@@ -59,7 +58,7 @@ class DataModel:
             yltxt = infile.read()
         return cls(yltxt, mod_path, description)
 
-    def __init__(self: DataModel, yltxt: str, mod_path: Tuple[str] = (".",),
+    def __init__(self, yltxt: str, mod_path: Tuple[str] = (".",),
                  description: str = None):
         """Initialize the class instance.
 
@@ -90,7 +89,7 @@ class DataModel:
             self.yang_library["ietf-yang-library:modules-state"]
             ["module-set-id"])
 
-    def module_set_id(self: DataModel) -> str:
+    def module_set_id(self) -> str:
         """Compute unique id of YANG modules comprising the data model.
 
         Returns:
@@ -99,7 +98,7 @@ class DataModel:
         fnames = sorted(["@".join(m) for m in self.schema_data.modules])
         return hashlib.sha1("".join(fnames).encode("ascii")).hexdigest()
 
-    def from_raw(self: DataModel, robj: RawObject) -> RootNode:
+    def from_raw(self, robj: RawObject) -> RootNode:
         """Create an instance node from a raw data tree.
 
         Args:
@@ -111,7 +110,7 @@ class DataModel:
         cooked = self.schema.from_raw(robj)
         return RootNode(cooked, self.schema, self.schema_data, cooked.timestamp)
 
-    def from_xml(self: DataModel, root: ET.Element) -> RootNode:
+    def from_xml(self, root: ET.Element) -> RootNode:
         """Create an instance node from a raw data tree.
 
         Args:
@@ -123,7 +122,7 @@ class DataModel:
         cooked = self.schema.from_xml(root)
         return RootNode(cooked, self.schema, self.schema_data, cooked.timestamp)
 
-    def get_schema_node(self: DataModel, path: SchemaPath) -> Optional[SchemaNode]:
+    def get_schema_node(self, path: SchemaPath) -> Optional[SchemaNode]:
         """Return the schema node addressed by a schema path.
 
         Args:
@@ -138,7 +137,7 @@ class DataModel:
         return self.schema.get_schema_descendant(
             self.schema_data.path2route(path))
 
-    def get_data_node(self: DataModel, path: DataPath) -> Optional[DataNode]:
+    def get_data_node(self, path: DataPath) -> Optional[DataNode]:
         """Return the data node addressed by a data path.
 
         Args:
@@ -158,7 +157,7 @@ class DataModel:
                 return None
         return node
 
-    def ascii_tree(self: DataModel, no_types: bool = False, val_count: bool = False) -> str:
+    def ascii_tree(self, no_types: bool = False, val_count: bool = False) -> str:
         """Generate ASCII art representation of the schema tree.
 
         Args:
@@ -170,17 +169,17 @@ class DataModel:
         """
         return self.schema._ascii_tree("", no_types, val_count)
 
-    def clear_val_counters(self: DataModel):
+    def clear_val_counters(self):
         """Clear validation counters in the entire schema tree."""
         self.schema.clear_val_counters()
 
-    def parse_instance_id(self: DataModel, text: str) -> InstanceRoute:
+    def parse_instance_id(self, text: str) -> InstanceRoute:
         return InstanceIdParser(text).parse()
 
-    def parse_resource_id(self: DataModel, text: str) -> InstanceRoute:
+    def parse_resource_id(self, text: str) -> InstanceRoute:
         return ResourceIdParser(text, self.schema).parse()
 
-    def schema_digest(self: DataModel) -> str:
+    def schema_digest(self) -> str:
         """Generate schema digest (to be used primarily by clients).
 
         Returns:
@@ -190,7 +189,7 @@ class DataModel:
         res["config"] = True
         return json.dumps(res)
 
-    def _build_schema(self: DataModel) -> None:
+    def _build_schema(self) -> None:
         for mid in self.schema_data._module_sequence:
             sctx = SchemaContext(
                 self.schema_data, self.schema_data.namespace(mid), mid)

--- a/yangson/datatype.py
+++ b/yangson/datatype.py
@@ -44,7 +44,6 @@ This module implements the following classes:
 * UnionType: YANG union type.
 """
 
-from __future__ import annotations
 import base64
 import decimal
 import numbers
@@ -70,7 +69,7 @@ class DataType:
 
     _option_template = '<option value="{}"{}>{}</option>'
 
-    def __init__(self: DataType, sctx: SchemaContext, name: Optional[YangIdentifier]):
+    def __init__(self, sctx: SchemaContext, name: Optional[YangIdentifier]):
         """Initialize the class instance."""
         self.sctx = sctx
         self.default = None
@@ -78,7 +77,7 @@ class DataType:
         self.error_tag = None
         self.error_message = None
 
-    def __contains__(self: DataType, val: ScalarValue) -> bool:
+    def __contains__(self, val: ScalarValue) -> bool:
         """Return ``True`` if the receiver type contains `val`.
 
         If the result is ``False``, set also `error_tag` and `error_message`
@@ -86,12 +85,12 @@ class DataType:
         """
         return True
 
-    def __str__(self: DataType):
+    def __str__(self):
         """Return YANG name of the receiver type."""
         base = self.yang_type()
         return f"{self.name}({base})" if self.name else base
 
-    def from_raw(self: DataType, raw: RawScalar) -> Optional[ScalarValue]:
+    def from_raw(self, raw: RawScalar) -> Optional[ScalarValue]:
         """Return a cooked value of the receiver type.
 
         The input argument should follow the rules for JSON
@@ -106,7 +105,7 @@ class DataType:
         if isinstance(raw, str):
             return raw
 
-    def from_xml(self: DataType, xml: ET.Element) -> Optional[ScalarValue]:
+    def from_xml(self, xml: ET.Element) -> Optional[ScalarValue]:
         """Return a cooked value of the received XML type.
 
         Args:
@@ -115,15 +114,15 @@ class DataType:
         if isinstance(xml.text, str):
             return xml.text
 
-    def to_raw(self: DataType, val: ScalarValue) -> Optional[RawScalar]:
+    def to_raw(self, val: ScalarValue) -> Optional[RawScalar]:
         """Return a raw value ready to be serialized in JSON."""
         return val
 
-    def to_xml(self: DataType, val: ScalarValue) -> Optional[str]:
+    def to_xml(self, val: ScalarValue) -> Optional[str]:
         """Return XML text value ready to be serialized in XML."""
         return str(val)
 
-    def parse_value(self: DataType, text: str) -> Optional[ScalarValue]:
+    def parse_value(self, text: str) -> Optional[ScalarValue]:
         """Parse value of the receiver's type.
 
         The input text should follow the rules for lexical
@@ -140,11 +139,11 @@ class DataType:
         """
         return self.from_raw(text)
 
-    def canonical_string(self: DataType, val: ScalarValue) -> Optional[str]:
+    def canonical_string(self, val: ScalarValue) -> Optional[str]:
         """Return canonical form of a value."""
         return str(val)
 
-    def from_yang(self: DataType, text: str) -> ScalarValue:
+    def from_yang(self, text: str) -> ScalarValue:
         """Parse value specified as default in a YANG module.
 
         Conformance to the receiving type isn't guaranteed.
@@ -160,16 +159,16 @@ class DataType:
             raise InvalidArgument(text)
         return res
 
-    def yang_type(self: DataType) -> YangIdentifier:
+    def yang_type(self) -> YangIdentifier:
         """Return YANG name of the receiver."""
         return self.__class__.__name__[:-4].lower()
 
-    def _set_error_info(self: DataType, error_tag: str = None, error_message: str = None):
+    def _set_error_info(self, error_tag: str = None, error_message: str = None):
         self.error_tag = error_tag if error_tag else "invalid-type"
         self.error_message = (error_message if error_message else
                               "expected " + str(self))
 
-    def _post_process(self: DataType, tnode: TerminalNode) -> None:
+    def _post_process(self, tnode: "TerminalNode") -> None:
         """Post-process the receiver type on behalf of a terminal node.
 
         By default do nothing.
@@ -216,18 +215,18 @@ class DataType:
         res._handle_restrictions(stmt, sctx)
         return res
 
-    def _deref(self: DataType, node: InstanceNode) -> List[InstanceNode]:
+    def _deref(self, node: InstanceNode) -> List[InstanceNode]:
         return []
 
-    def _handle_properties(self: DataType, stmt: Statement, sctx: SchemaContext) -> None:
+    def _handle_properties(self, stmt: Statement, sctx: SchemaContext) -> None:
         """Handle type substatements."""
         self._handle_restrictions(stmt, sctx)
 
-    def _handle_restrictions(self: DataType, stmt: Statement, sctx: SchemaContext) -> None:
+    def _handle_restrictions(self, stmt: Statement, sctx: SchemaContext) -> None:
         """Handle type restriction substatements."""
         pass
 
-    def _type_digest(self: DataType, config: bool) -> Dict[str, Any]:
+    def _type_digest(self, config: bool) -> Dict[str, Any]:
         """Return receiver's type digest.
 
         Args:
@@ -242,72 +241,72 @@ class DataType:
 class EmptyType(DataType):
     """Class representing YANG "empty" type."""
 
-    def canonical_string(self: EmptyType, val: Tuple[None]) -> Optional[str]:
+    def canonical_string(self, val: Tuple[None]) -> Optional[str]:
         return ""
 
-    def __contains__(self: EmptyType, val: Tuple[None]) -> bool:
+    def __contains__(self, val: Tuple[None]) -> bool:
         if val == (None,):
             return True
         self._set_error_info()
         return False
 
-    def parse_value(self: EmptyType, text: str) -> Optional[Tuple[None]]:
+    def parse_value(self, text: str) -> Optional[Tuple[None]]:
         if text == "":
             return (None,)
 
-    def from_raw(self: EmptyType, raw: RawScalar) -> Optional[Tuple[None]]:
+    def from_raw(self, raw: RawScalar) -> Optional[Tuple[None]]:
         if raw == [None]:
             return (None,)
 
-    def to_raw(self: EmptyType, val: Tuple[None]) -> List[None]:
+    def to_raw(self, val: Tuple[None]) -> List[None]:
         return [None]
 
-    def from_xml(self: EmptyType, xml: str) -> Optional[Tuple[None]]:
+    def from_xml(self, xml: str) -> Optional[Tuple[None]]:
         if xml == '':
             return (None,)
 
-    def to_xml(self: EmptyType, val: Tuple[None]) -> None:
+    def to_xml(self, val: Tuple[None]) -> None:
         return None
 
 
 class BitsType(DataType):
     """Class representing YANG "bits" type."""
 
-    def __init__(self: BitsType, sctx: SchemaContext, name: YangIdentifier):
+    def __init__(self, sctx: SchemaContext, name: YangIdentifier):
         """Initialize the class instance."""
         super().__init__(sctx, name)
         self.bit = {}
 
-    def sorted_bits(self: BitsType) -> List[Tuple[str, int]]:
+    def sorted_bits(self) -> List[Tuple[str, int]]:
         """Return list of bit items sorted by position."""
         return sorted(self.bit.items(), key=lambda x: x[1])
 
-    def from_raw(self: BitsType, raw: RawScalar) -> Optional[Tuple[str]]:
+    def from_raw(self, raw: RawScalar) -> Optional[Tuple[str]]:
         try:
             return tuple(raw.split())
         except AttributeError:
             return None
 
-    def from_xml(self: BitsType, xml: ET.Element) -> Optional[Tuple[str]]:
+    def from_xml(self, xml: ET.Element) -> Optional[Tuple[str]]:
         try:
             return tuple(xml.text.split())
         except AttributeError:
             return None
 
-    def __contains__(self: BitsType, val: Tuple[str]) -> bool:
+    def __contains__(self, val: Tuple[str]) -> bool:
         for b in val:
             if b not in self.bit:
                 self._set_error_info(error_message="unknown bit " + b)
                 return False
         return True
 
-    def to_raw(self: BitsType, val: Tuple[str]) -> str:
+    def to_raw(self, val: Tuple[str]) -> str:
         return self.canonical_string(val)
 
-    def to_xml(self: BitsType, val: Tuple[str]) -> str:
+    def to_xml(self, val: Tuple[str]) -> str:
         return self.canonical_string(val)
 
-    def as_int(self: BitsType, val: Tuple[str]) -> int:
+    def as_int(self, val: Tuple[str]) -> int:
         """Transform a "bits" value to an integer."""
         res = 0
         try:
@@ -317,7 +316,7 @@ class BitsType(DataType):
             return None
         return res
 
-    def canonical_string(self: BitsType, val: Tuple[str]) -> Optional[str]:
+    def canonical_string(self, val: Tuple[str]) -> Optional[str]:
         try:
             items = [(self.bit[b], b) for b in val]
         except KeyError:
@@ -325,7 +324,7 @@ class BitsType(DataType):
         items.sort()
         return " ".join([x[1] for x in items])
 
-    def _handle_properties(self: BitsType, stmt: Statement, sctx: SchemaContext) -> None:
+    def _handle_properties(self, stmt: Statement, sctx: SchemaContext) -> None:
         """Handle **bit** statements."""
         nextpos = 0
         for bst in stmt.find_all("bit"):
@@ -342,7 +341,7 @@ class BitsType(DataType):
                 self.bit[label] = nextpos
             nextpos += 1
 
-    def _handle_restrictions(self: BitsType, stmt: Statement, sctx: SchemaContext) -> None:
+    def _handle_restrictions(self, stmt: Statement, sctx: SchemaContext) -> None:
         bst = stmt.find_all("bit")
         if not bst:
             return
@@ -351,7 +350,7 @@ class BitsType(DataType):
         for bit in set(self.bit) - new:
             del self.bit[bit]
 
-    def _type_digest(self: BitsType, config: bool) -> Dict[str, Any]:
+    def _type_digest(self, config: bool) -> Dict[str, Any]:
         res = super()._type_digest(config)
         bits = []
         i = 0
@@ -367,18 +366,18 @@ class BitsType(DataType):
 class BooleanType(DataType):
     """Class representing YANG "boolean" type."""
 
-    def __contains__(self: BooleanType, val: bool) -> bool:
+    def __contains__(self, val: bool) -> bool:
         if isinstance(val, bool):
             return True
         self._set_error_info()
         return False
 
-    def from_raw(self: BooleanType, raw: RawScalar) -> Optional[bool]:
+    def from_raw(self, raw: RawScalar) -> Optional[bool]:
         """Override superclass method."""
         if isinstance(raw, bool):
             return raw
 
-    def from_xml(self: BooleanType, xml: ET.Element) -> Optional[ScalarValue]:
+    def from_xml(self, xml: ET.Element) -> Optional[ScalarValue]:
         """Return a cooked value of the received XML type.
 
         Args:
@@ -386,7 +385,7 @@ class BooleanType(DataType):
         """
         return self.parse_value(xml.text)
 
-    def parse_value(self: BooleanType, text: str) -> Optional[bool]:
+    def parse_value(self, text: str) -> Optional[bool]:
         """Parse boolean value.
 
         Args:
@@ -397,7 +396,7 @@ class BooleanType(DataType):
         if text == "false":
             return False
 
-    def canonical_string(self: BooleanType, val: bool) -> Optional[str]:
+    def canonical_string(self, val: bool) -> Optional[str]:
         if val is True:
             return "true"
         if val is False:
@@ -407,12 +406,12 @@ class BooleanType(DataType):
 class LinearType(DataType):
     """Abstract class representing character or byte sequences."""
 
-    def __init__(self: LinearType, sctx: SchemaContext, name: YangIdentifier):
+    def __init__(self, sctx: SchemaContext, name: YangIdentifier):
         """Initialize the class instance."""
         super().__init__(sctx, name)
         self.length = None  # type: Optional[Intervals]
 
-    def _handle_restrictions(self: LinearType, stmt: Statement, sctx: SchemaContext) -> None:
+    def _handle_restrictions(self, stmt: Statement, sctx: SchemaContext) -> None:
         lstmt = stmt.find1("length")
         if lstmt:
             if self.length is None:
@@ -420,13 +419,13 @@ class LinearType(DataType):
                     [[0, 4294967295]], error_message="invalid length")
             self.length.restrict_with(lstmt.argument, *lstmt.get_error_info())
 
-    def __contains__(self: LinearType, val: Union[str, bytes]) -> bool:
+    def __contains__(self, val: Union[str, bytes]) -> bool:
         if self.length and len(val) not in self.length:
             self._set_error_info(self.length.error_tag, self.length.error_message)
             return False
         return True
 
-    def _type_digest(self: LinearType, config: bool) -> Dict[str, Any]:
+    def _type_digest(self, config: bool) -> Dict[str, Any]:
         res = super()._type_digest(config)
         if self.length:
             res["length"] = self.length.intervals
@@ -436,19 +435,19 @@ class LinearType(DataType):
 class StringType(LinearType):
     """Class representing YANG "string" type."""
 
-    def __init__(self: StringType, sctx: SchemaContext, name: YangIdentifier):
+    def __init__(self, sctx: SchemaContext, name: YangIdentifier):
         """Initialize the class instance."""
         super().__init__(sctx, name)
         self.patterns = []  # type: List[Pattern]
 
-    def _handle_restrictions(self: StringType, stmt: Statement, sctx: SchemaContext) -> None:
+    def _handle_restrictions(self, stmt: Statement, sctx: SchemaContext) -> None:
         super()._handle_restrictions(stmt, sctx)
         for pst in stmt.find_all("pattern"):
             invm = pst.find1("modifier", "invert-match") is not None
             self.patterns.append(Pattern(
                 pst.argument, invm, *pst.get_error_info()))
 
-    def __contains__(self: StringType, val: str) -> bool:
+    def __contains__(self, val: str) -> bool:
         if not isinstance(val, str):
             self._set_error_info()
             return False
@@ -460,7 +459,7 @@ class StringType(LinearType):
                 return False
         return True
 
-    def _type_digest(self: StringType, config: bool) -> Dict[str, Any]:
+    def _type_digest(self, config: bool) -> Dict[str, Any]:
         res = super()._type_digest(config)
         pats = [p.pattern for p in self.patterns if not p.invert_match]
         ipats = [p.pattern for p in self.patterns if p.invert_match]
@@ -474,55 +473,55 @@ class StringType(LinearType):
 class BinaryType(LinearType):
     """Class representing YANG "binary" type."""
 
-    def from_raw(self: BinaryType, raw: RawScalar) -> Optional[bytes]:
+    def from_raw(self, raw: RawScalar) -> Optional[bytes]:
         """Override superclass method."""
         try:
             return base64.b64decode(raw, validate=True)
         except TypeError:
             return None
 
-    def from_xml(self: BinaryType, xml: ET.Element) -> Optional[bytes]:
+    def from_xml(self, xml: ET.Element) -> Optional[bytes]:
         """Override superclass method."""
         try:
             return base64.b64decode(xml.text, validate=True)
         except TypeError:
             return None
 
-    def __contains__(self: BinaryType, val: bytes) -> bool:
+    def __contains__(self, val: bytes) -> bool:
         if not isinstance(val, bytes):
             self._set_error_info()
             return False
         return super().__contains__(val)
 
-    def to_raw(self: BinaryType, val: bytes) -> str:
+    def to_raw(self, val: bytes) -> str:
         return self.canonical_string(val)
 
-    def to_xml(self: BinaryType, val: bytes) -> str:
+    def to_xml(self, val: bytes) -> str:
         return self.canonical_string(val)
 
-    def canonical_string(self: BinaryType, val: bytes) -> Optional[str]:
+    def canonical_string(self, val: bytes) -> Optional[str]:
         return base64.b64encode(val).decode("ascii")
 
 
 class EnumerationType(DataType):
     """Class representing YANG "enumeration" type."""
 
-    def __init__(self: EnumerationType, sctx: SchemaContext, name: YangIdentifier):
+    def __init__(self, sctx: SchemaContext, name: YangIdentifier):
         """Initialize the class instance."""
         super().__init__(sctx, name)
         self.enum = {}  # type: Dict[str, int]
 
-    def sorted_enums(self: EnumerationType) -> List[Tuple[str, int]]:
+    def sorted_enums(self) -> List[Tuple[str, int]]:
         """Return list of enum items sorted by value."""
         return sorted(self.enum.items(), key=lambda x: x[1])
 
-    def __contains__(self: EnumerationType, val: str) -> bool:
+    def __contains__(self, val: str) -> bool:
         if val in self.enum:
             return True
         self._set_error_info()
         return False
 
-    def _handle_properties(self: EnumerationType, stmt: Statement, sctx: SchemaContext) -> None:
+    def _handle_properties(self, stmt: Statement, sctx: SchemaContext) -> None:
         """Handle **enum** statements."""
         nextval = 0
         for est in stmt.find_all("enum"):
@@ -539,7 +538,7 @@ class EnumerationType(DataType):
                 self.enum[label] = nextval
             nextval += 1
 
-    def _handle_restrictions(self: EnumerationType, stmt: Statement, sctx: SchemaContext) -> None:
+    def _handle_restrictions(self, stmt: Statement, sctx: SchemaContext) -> None:
         est = stmt.find_all("enum")
         if not est:
             return
@@ -548,7 +547,7 @@ class EnumerationType(DataType):
         for en in set(self.enum) - new:
             del self.enum[en]
 
-    def _type_digest(self: EnumerationType, config: bool) -> Dict[str, Any]:
+    def _type_digest(self, config: bool) -> Dict[str, Any]:
         res = super()._type_digest(config)
         if config:
             res["enums"] = list(self.enum.keys())
@@ -558,12 +557,12 @@ class EnumerationType(DataType):
 class LinkType(DataType):
     """Abstract class for instance-referencing types."""
 
-    def __init__(self: LinkType, sctx: SchemaContext, name: YangIdentifier):
+    def __init__(self, sctx: SchemaContext, name: YangIdentifier):
         """Initialize the class instance."""
         super().__init__(sctx, name)
         self.require_instance = True  # type: bool
 
-    def _handle_restrictions(self: LinkType, stmt: Statement, sctx: SchemaContext) -> None:
+    def _handle_restrictions(self, stmt: Statement, sctx: SchemaContext) -> None:
         if stmt.find1("require-instance", "false"):
             self.require_instance = False
 
@@ -571,52 +570,52 @@ class LinkType(DataType):
 class LeafrefType(LinkType):
     """Class representing YANG "leafref" type."""
 
-    def __init__(self: LeafrefType, sctx: SchemaContext, name: YangIdentifier):
+    def __init__(self, sctx: SchemaContext, name: YangIdentifier):
         """Initialize the class instance."""
         super().__init__(sctx, name)
         self.path = None
         self.ref_type = None
 
-    def _handle_properties(self: LeafrefType, stmt: Statement, sctx: SchemaContext) -> None:
+    def _handle_properties(self, stmt: Statement, sctx: SchemaContext) -> None:
         super()._handle_properties(stmt, sctx)
         self.path = XPathParser(
             stmt.find1("path", required=True).argument, sctx).parse()
 
-    def canonical_string(self: LeafrefType, val: ScalarValue) -> Optional[str]:
+    def canonical_string(self, val: ScalarValue) -> Optional[str]:
         return self.ref_type.canonical_string(val)
 
-    def __contains__(self: LeafrefType, val: ScalarValue) -> bool:
+    def __contains__(self, val: ScalarValue) -> bool:
         return val in self.ref_type
 
-    def from_raw(self: LeafrefType, raw: RawScalar) -> Optional[ScalarValue]:
+    def from_raw(self, raw: RawScalar) -> Optional[ScalarValue]:
         return self.ref_type.from_raw(raw)
 
-    def from_xml(self: LeafrefType, xml: ET.Element) -> Optional[bytes]:
+    def from_xml(self, xml: ET.Element) -> Optional[bytes]:
         return self.ref_type.from_xml(xml)
 
-    def to_raw(self: LeafrefType, val: ScalarValue) -> RawScalar:
+    def to_raw(self, val: ScalarValue) -> RawScalar:
         return self.ref_type.to_raw(val)
 
-    def to_xml(self: LeafrefType, val: ScalarValue) -> RawScalar:
+    def to_xml(self, val: ScalarValue) -> RawScalar:
         return self.ref_type.to_xml(val)
 
-    def parse_value(self: LeafrefType, text: str) -> Optional[ScalarValue]:
+    def parse_value(self, text: str) -> Optional[ScalarValue]:
         return self.ref_type.parse_value(text)
 
-    def from_yang(self: LeafrefType, text: str) -> ScalarValue:
+    def from_yang(self, text: str) -> ScalarValue:
         return self.ref_type.from_yang(text)
 
-    def _deref(self: LeafrefType, node: InstanceNode) -> List[InstanceNode]:
+    def _deref(self, node: InstanceNode) -> List[InstanceNode]:
         ns = self.path.evaluate(node)
         return [n for n in ns if str(n) == str(node)]
 
-    def _post_process(self: LeafrefType, tnode: TerminalNode) -> None:
+    def _post_process(self, tnode: "TerminalNode") -> None:
         ref = tnode._follow_leafref(self.path, tnode)
         if ref is None:
             raise InvalidLeafrefPath(tnode.qual_name)
         self.ref_type = ref.type
 
-    def _type_digest(self: LeafrefType, config: bool) -> Dict[str, Any]:
+    def _type_digest(self, config: bool) -> Dict[str, Any]:
         res = super()._type_digest(config)
         res["ref_type"] = self.ref_type._type_digest(config)
         return res
@@ -625,54 +624,54 @@ class LeafrefType(LinkType):
 class InstanceIdentifierType(LinkType):
     """Class representing YANG "instance-identifier" type."""
 
-    def __str__(self: InstanceIdentifierType):
+    def __str__(self):
         return "instance-identifier"
 
-    def yang_type(self: InstanceIdentifierType) -> YangIdentifier:
+    def yang_type(self) -> YangIdentifier:
         """Override the superclass method."""
         return "instance-identifier"
 
-    def from_raw(self: InstanceIdentifierType, raw: RawScalar) -> Optional[InstanceRoute]:
+    def from_raw(self, raw: RawScalar) -> Optional[InstanceRoute]:
         try:
             return InstanceIdParser(raw).parse()
         except ParserException:
             return None
 
-    def from_xml(self: InstanceIdentifierType, xml: ET.Element) -> Optional[InstanceRoute]:
+    def from_xml(self, xml: ET.Element) -> Optional[InstanceRoute]:
         return self.from_raw(xml.text)
 
-    def to_raw(self: InstanceIdentifierType, val: InstanceRoute) -> str:
+    def to_raw(self, val: InstanceRoute) -> str:
         """Override the superclass method."""
         return str(val)
 
-    def to_xml(self: InstanceIdentifierType, val: InstanceRoute) -> str:
+    def to_xml(self, val: InstanceRoute) -> str:
         """Override the superclass method."""
         return str(val)
 
-    def from_yang(self: InstanceIdentifierType, text: str) -> InstanceRoute:
+    def from_yang(self, text: str) -> InstanceRoute:
         """Override the superclass method."""
         return XPathParser(text, self.sctx).parse().as_instance_route()
 
-    def _deref(self: InstanceIdentifierType, node: InstanceNode) -> List[InstanceNode]:
+    def _deref(self, node: InstanceNode) -> List[InstanceNode]:
         return [node.top().goto(node.value)]
 
 
 class IdentityrefType(DataType):
     """Class representing YANG "identityref" type."""
 
-    def __init__(self: IdentityrefType, sctx: SchemaContext, name: YangIdentifier):
+    def __init__(self, sctx: SchemaContext, name: YangIdentifier):
         """Initialize the class instance."""
         super().__init__(sctx, name)
         self.bases = []  # type: List[QualName]
 
-    def from_raw(self: IdentityrefType, raw: RawScalar) -> Optional[QualName]:
+    def from_raw(self, raw: RawScalar) -> Optional[QualName]:
         try:
             i1, s, i2 = raw.partition(":")
         except AttributeError:
             return None
         return (i2, i1) if s else (i1, self.sctx.default_ns)
 
-    def from_xml(self: IdentityrefType, xml: ET.Element) -> Optional[QualName]:
+    def from_xml(self, xml: ET.Element) -> Optional[QualName]:
         try:
             i1, s, i2 = xml.text.partition(":")
         except AttributeError:
@@ -688,20 +687,20 @@ class IdentityrefType(DataType):
             raise MissingModuleNamespace(ns_url)
         return (i2, module.main_module[0])
 
-    def __contains__(self: IdentityrefType, val: QualName) -> bool:
+    def __contains__(self, val: QualName) -> bool:
         for b in self.bases:
             if not self.sctx.schema_data.is_derived_from(val, b):
                 self._set_error_info(error_message=f"not derived from {b[1]}:{b[0]}")
                 return False
         return True
 
-    def to_raw(self: IdentityrefType, val: QualName) -> str:
+    def to_raw(self, val: QualName) -> str:
         return self.canonical_string(val)
 
-    def to_xml(self: IdentityrefType, val: QualName) -> str:
+    def to_xml(self, val: QualName) -> str:
         return self.canonical_string(val)
 
-    def from_yang(self: IdentityrefType, text: str) -> QualName:
+    def from_yang(self, text: str) -> QualName:
         """Override the superclass method."""
         try:
             return self.sctx.schema_data.translate_pname(
@@ -709,17 +708,17 @@ class IdentityrefType(DataType):
         except (ModuleNotRegistered, UnknownPrefix):
             raise InvalidArgument(text)
 
-    def canonical_string(self: IdentityrefType, val: ScalarValue) -> Optional[str]:
+    def canonical_string(self, val: ScalarValue) -> Optional[str]:
         """Return canonical form of a value."""
         return f"{val[1]}:{val[0]}"
 
-    def _handle_properties(self: IdentityrefType, stmt: Statement, sctx: SchemaContext) -> None:
+    def _handle_properties(self, stmt: Statement, sctx: SchemaContext) -> None:
         self.bases = []
         for b in stmt.find_all("base"):
             self.bases.append(
                 sctx.schema_data.translate_pname(b.argument, sctx.text_mid))
 
-    def _type_digest(self: IdentityrefType, config: bool) -> Dict[str, Any]:
+    def _type_digest(self, config: bool) -> Dict[str, Any]:
         res = super()._type_digest(config)
         if config:
             res["identities"] = list(
@@ -730,12 +729,12 @@ class IdentityrefType(DataType):
 class NumericType(DataType):
     """Abstract class for numeric data types."""
 
-    def __init__(self: NumericType, sctx: SchemaContext, name: YangIdentifier):
+    def __init__(self, sctx: SchemaContext, name: YangIdentifier):
         """Initialize the class instance."""
         super().__init__(sctx, name)
         self.range = None  # type: Optional[Intervals]
 
-    def __contains__(self: NumericType, val: Union[int, decimal.Decimal]) -> bool:
+    def __contains__(self, val: Union[int, decimal.Decimal]) -> bool:
         if self.range is None:
             if self._range[0] <= val <= self._range[1]:
                 return True
@@ -747,7 +746,7 @@ class NumericType(DataType):
         self._set_error_info(self.range.error_tag, self.range.error_message)
         return False
 
-    def _handle_restrictions(self: NumericType, stmt: Statement, sctx: SchemaContext) -> None:
+    def _handle_restrictions(self, stmt: Statement, sctx: SchemaContext) -> None:
         rstmt = stmt.find1("range")
         if rstmt:
             if self.range is None:
@@ -755,7 +754,7 @@ class NumericType(DataType):
                                        error_message="not in range")
             self.range.restrict_with(rstmt.argument, *rstmt.get_error_info())
 
-    def _type_digest(self: NumericType, config: bool) -> Dict[str, Any]:
+    def _type_digest(self, config: bool) -> Dict[str, Any]:
         res = super()._type_digest(config)
         if self.range:
             res["range"] = [[self.to_raw(r[0]), self.to_raw(r[-1])]
@@ -766,24 +765,24 @@ class NumericType(DataType):
 class Decimal64Type(NumericType):
     """Class representing YANG "decimal64" type."""
 
-    def __init__(self: Decimal64Type, sctx: SchemaContext, name: YangIdentifier):
+    def __init__(self, sctx: SchemaContext, name: YangIdentifier):
         """Initialize the class instance."""
         super().__init__(sctx, name)
         self._epsilon = decimal.Decimal(0)  # type: decimal.Decimal
 
     @property
-    def _range(self: Decimal64Type) -> List[decimal.Decimal]:
+    def _range(self) -> List[decimal.Decimal]:
         quot = decimal.Decimal(10**self.fraction_digits)
         lim = decimal.Decimal(9223372036854775808)
         return [-lim / quot, (lim - 1) / quot]
 
-    def _handle_properties(self: Decimal64Type, stmt: Statement, sctx: SchemaContext) -> None:
+    def _handle_properties(self, stmt: Statement, sctx: SchemaContext) -> None:
         self.fraction_digits = int(
             stmt.find1("fraction-digits", required=True).argument)
         self._epsilon = decimal.Decimal(10) ** -self.fraction_digits
         super()._handle_properties(stmt, sctx)
 
-    def from_raw(self: Decimal64Type, raw: RawScalar) -> Optional[decimal.Decimal]:
+    def from_raw(self, raw: RawScalar) -> Optional[decimal.Decimal]:
         """Override superclass method.
 
         According to [RFC7951]_, a raw instance must be string.
@@ -795,31 +794,31 @@ class Decimal64Type(NumericType):
         except decimal.InvalidOperation:
             return None
 
-    def from_xml(self: Decimal64Type, xml: ET.Element) -> Optional[decimal.Decimal]:
+    def from_xml(self, xml: ET.Element) -> Optional[decimal.Decimal]:
         try:
             return decimal.Decimal(xml.text).quantize(self._epsilon)
         except decimal.InvalidOperation:
             return None
 
-    def to_raw(self: Decimal64Type, val: decimal.Decimal) -> str:
+    def to_raw(self, val: decimal.Decimal) -> str:
         return self.canonical_string(val)
 
-    def to_xml(self: Decimal64Type, val: decimal.Decimal) -> str:
+    def to_xml(self, val: decimal.Decimal) -> str:
         return self.canonical_string(val)
 
-    def canonical_string(self: Decimal64Type, val: decimal.Decimal) -> Optional[str]:
+    def canonical_string(self, val: decimal.Decimal) -> Optional[str]:
         if val == 0:
             return "0.0"
         sval = str(val.quantize(self._epsilon)).rstrip("0")
         return (sval + "0") if sval.endswith(".") else sval
 
-    def __contains__(self: Decimal64Type, val: decimal.Decimal) -> bool:
+    def __contains__(self, val: decimal.Decimal) -> bool:
         if not isinstance(val, decimal.Decimal):
             self._set_error_info()
             return False
         return super().__contains__(val)
 
-    def _type_digest(self: Decimal64Type, config: bool) -> Dict[str, Any]:
+    def _type_digest(self, config: bool) -> Dict[str, Any]:
         res = super()._type_digest(config)
         res["fraction_digits"] = self.fraction_digits
         return res
@@ -831,20 +830,20 @@ class IntegralType(NumericType):
     octhex = re.compile("[-+]?0([x0-9])")
     """Regular expression for octal or hexadecimal default."""
 
-    def __contains__(self: IntegralType, val: int) -> bool:
+    def __contains__(self, val: int) -> bool:
         if not isinstance(val, int) or isinstance(val, bool):
             self._set_error_info()
             return False
         return super().__contains__(val)
 
-    def parse_value(self: IntegralType, text: str) -> Optional[int]:
+    def parse_value(self, text: str) -> Optional[int]:
         """Override superclass method."""
         try:
             return int(text)
         except ValueError:
             return None
 
-    def from_raw(self: IntegralType, raw: RawScalar) -> Optional[int]:
+    def from_raw(self, raw: RawScalar) -> Optional[int]:
         if not isinstance(raw, int) or isinstance(raw, bool):
             return None
         try:
@@ -852,13 +851,13 @@ class IntegralType(NumericType):
         except (ValueError, TypeError):
             return None
 
-    def from_xml(self: IntegralType, xml: ET.Element) -> Optional[int]:
+    def from_xml(self, xml: ET.Element) -> Optional[int]:
         try:
             return int(xml.text)
         except (ValueError, TypeError):
             return None
 
-    def from_yang(self: IntegralType, text: str) -> int:
+    def from_yang(self, text: str) -> int:
         """Override the superclass method."""
         mo = self.octhex.match(text)
         if mo:
@@ -894,7 +893,7 @@ class Int64Type(IntegralType):
 
     _range = [-9223372036854775808, 9223372036854775807]
 
-    def from_raw(self: Int64Type, raw: RawScalar) -> Optional[int]:
+    def from_raw(self, raw: RawScalar) -> Optional[int]:
         """Override superclass method.
 
         According to [RFC7951]_, a raw instance must be string.
@@ -906,7 +905,7 @@ class Int64Type(IntegralType):
         except (ValueError, TypeError):
             return None
 
-    def from_xml(self: Int64Type, xml: ET.Element) -> Optional[int]:
+    def from_xml(self, xml: ET.Element) -> Optional[int]:
         """Override superclass method.
 
         XML is always delivered as a text element
@@ -916,10 +915,10 @@ class Int64Type(IntegralType):
         except (ValueError, TypeError):
             return None
 
-    def to_raw(self: Int64Type, val: int) -> str:
+    def to_raw(self, val: int) -> str:
         return self.canonical_string(val)
 
-    def to_xml(self: Int64Type, val: int) -> str:
+    def to_xml(self, val: int) -> str:
         return self.canonical_string(val)
 
 
@@ -946,7 +945,7 @@ class Uint64Type(IntegralType):
 
     _range = [0, 18446744073709551615]
 
-    def from_raw(self: Uint64Type, raw: str) -> Optional[int]:
+    def from_raw(self, raw: str) -> Optional[int]:
         """Override superclass method.
 
         According to [RFC7951]_, a raw instance must be string.
@@ -958,7 +957,7 @@ class Uint64Type(IntegralType):
         except (ValueError, TypeError):
             return None
 
-    def from_xml(self: Uint64Type, xml: ET.Element) -> Optional[int]:
+    def from_xml(self, xml: ET.Element) -> Optional[int]:
         """Override superclass method.
 
         XML is always delivered as a text element
@@ -968,59 +967,59 @@ class Uint64Type(IntegralType):
         except (ValueError, TypeError):
             return None
 
-    def to_raw(self: Uint64Type, val: int) -> str:
+    def to_raw(self, val: int) -> str:
         return self.canonical_string(val)
 
-    def to_xml(self: Uint64Type, val: int) -> str:
+    def to_xml(self, val: int) -> str:
         return self.canonical_string(val)
 
 
 class UnionType(DataType):
     """Class representing YANG "union" type."""
 
-    def __init__(self: UnionType, sctx: SchemaContext, name: YangIdentifier):
+    def __init__(self, sctx: SchemaContext, name: YangIdentifier):
         """Initialize the class instance."""
         super().__init__(sctx, name)
         self.types = []  # type: List[DataType]
 
-    def to_raw(self: UnionType, val: ScalarValue) -> RawScalar:
+    def to_raw(self, val: ScalarValue) -> RawScalar:
         for t in self.types:
             if val in t:
                 return t.to_raw(val)
 
-    def to_xml(self: UnionType, val: ScalarValue) -> RawScalar:
+    def to_xml(self, val: ScalarValue) -> RawScalar:
         for t in self.types:
             if val in t:
                 return t.to_xml(val)
 
-    def canonical_string(self: UnionType, val: ScalarValue) -> Optional[str]:
+    def canonical_string(self, val: ScalarValue) -> Optional[str]:
         for t in self.types:
             if val in t:
                 return t.canonical_string(val)
         return None
 
-    def parse_value(self: UnionType, text: str) -> Optional[ScalarValue]:
+    def parse_value(self, text: str) -> Optional[ScalarValue]:
         for t in self.types:
             val = t.parse_value(text)
             if val is not None and val in t:
                 return val
         return None
 
-    def from_raw(self: UnionType, raw: RawScalar) -> Optional[ScalarValue]:
+    def from_raw(self, raw: RawScalar) -> Optional[ScalarValue]:
         for t in self.types:
             val = t.from_raw(raw)
             if val is not None and val in t:
                 return val
         return None
 
-    def from_xml(self: UnionType, xml: ET.Element) -> Optional[ScalarValue]:
+    def from_xml(self, xml: ET.Element) -> Optional[ScalarValue]:
         for t in self.types:
             val = t.from_xml(xml)
             if val is not None and val in t:
                 return val
         return None
 
-    def __contains__(self: UnionType, val: Any) -> bool:
+    def __contains__(self, val: Any) -> bool:
         for t in self.types:
             try:
                 if val in t:
@@ -1029,11 +1028,11 @@ class UnionType(DataType):
                 continue
         return False
 
-    def _handle_properties(self: UnionType, stmt: Statement, sctx: SchemaContext) -> None:
+    def _handle_properties(self, stmt: Statement, sctx: SchemaContext) -> None:
         self.types = [self._resolve_type(ts, sctx)
                       for ts in stmt.find_all("type")]
 
-    def _post_process(self: UnionType, tnode: TerminalNode) -> None:
+    def _post_process(self, tnode: "TerminalNode") -> None:
         for t in self.types:
             t._post_process(tnode)
 

--- a/yangson/enumerations.py
+++ b/yangson/enumerations.py
@@ -17,7 +17,6 @@
 
 """Enumeration classes."""
 
-from __future__ import annotations
 from enum import Enum
 
 
@@ -78,7 +77,7 @@ class Axis(Enum):
     self = 10
     """Just the context node."""
 
-    def __str__(self: Axis) -> str:
+    def __str__(self) -> str:
         """Return string representation of the axis."""
         return self.name.replace("_", "-")
 
@@ -93,6 +92,6 @@ class MultiplicativeOp(Enum):
     modulo = "mod"
     """Modulo operator (``mod``)."""
 
-    def __str__(self: MultiplicativeOp) -> str:
+    def __str__(self) -> str:
         """Return string representation of the operation."""
         return self.value

--- a/yangson/exceptions.py
+++ b/yangson/exceptions.py
@@ -69,7 +69,6 @@ This module defines the following exceptions:
 * :exc:`YangTypeError`: A scalar value is of incorrect type.
 """
 
-from __future__ import annotations
 from typing import TYPE_CHECKING
 from .typealiases import (InstanceName, JSONPointer, ModuleId, PrefName,
                           QualName, ScalarValue, YangIdentifier)
@@ -83,72 +82,72 @@ class YangsonException(Exception):
 class AnnotationException(YangsonException):
     """Abstract class for exceptions related to metadata annotations."""
 
-    def __init__(self: AnnotationException, path: JSONPointer):
+    def __init__(self, path: JSONPointer):
         self.path = path
 
 
 class MissingAnnotationTarget(AnnotationException):
     """Instance node that is being annotated doesn't exist."""
 
-    def __init__(self: MissingAnnotationTarget, path: JSONPointer, iname: InstanceName):
+    def __init__(self, path: JSONPointer, iname: InstanceName):
         super().__init__(path)
         self.iname = iname
 
-    def __str__(self: MissingAnnotationTarget):
+    def __str__(self):
         return f"[{self.path}] no instance '{self.iname}'"
 
 
 class UndefinedAnnotation(AnnotationException):
     """Undefined annotation is used."""
 
-    def __init__(self: UndefinedAnnotation, path: JSONPointer, aname: InstanceName):
+    def __init__(self, path: JSONPointer, aname: InstanceName):
         super().__init__(path)
         self.aname = aname
 
-    def __str__(self: UndefinedAnnotation):
+    def __str__(self):
         return f"[{self.path}] Undefined annotation '{self.aname}'"
 
 
 class AnnotationTypeError(AnnotationException):
     """Type of annotation is incorrect."""
 
-    def __init__(self: AnnotationTypeError, path: JSONPointer, aname: InstanceName, msg: str):
+    def __init__(self, path: JSONPointer, aname: InstanceName, msg: str):
         super().__init__(path)
         self.aname = aname
         self.msg = msg
 
-    def __str__(self: AnnotationTypeError):
+    def __str__(self):
         return f"[{self.path}] value of '{self.aname}' {self.msg}"
 
 
 class InvalidArgument(YangsonException):
     """The argument of a statement is invalid."""
 
-    def __init__(self: InvalidArgument, arg: str):
+    def __init__(self, arg: str):
         self.argument = arg
 
-    def __str__(self: InvalidArgument):
+    def __str__(self):
         return self.argument
 
 
 class InvalidKeyValue(YangsonException):
     """List key or leaf-list value is invalid."""
 
-    def __init__(self: InvalidKeyValue, value: ScalarValue):
+    def __init__(self, value: ScalarValue):
         self.value = value
 
-    def __str__(self: InvalidKeyValue):
+    def __str__(self):
         return str(self.value)
 
 
 class InstanceException(YangsonException):
     """Abstract class for exceptions related to operations on instance nodes."""
 
-    def __init__(self: InstanceException, path: JSONPointer, message: str):
+    def __init__(self, path: JSONPointer, message: str):
         self.path = path
         self.message = message
 
-    def __str__(self: InstanceException):
+    def __str__(self):
         return f"[{self.path}] {self.message}"
 
 
@@ -168,10 +167,10 @@ class NonDataNode(InstanceException):
 class ParserException(YangsonException):
     """Base class for parser exceptions."""
 
-    def __init__(self: ParserException, parser: Parser):
+    def __init__(self, parser: "Parser"):
         self.parser = parser
 
-    def __str__(self: ParserException) -> str:
+    def __str__(self) -> str:
         """Print parser state."""
         if "\n" in self.parser.input:
             (line, col) = self.parser.line_column()
@@ -186,11 +185,11 @@ class EndOfInput(ParserException):
 class UnexpectedInput(ParserException):
     """Unexpected input."""
 
-    def __init__(self: UnexpectedInput, parser: Parser, expected: str = None):
+    def __init__(self, parser: "Parser", expected: str = None):
         super().__init__(parser)
         self.expected = expected
 
-    def __str__(self: UnexpectedInput) -> str:
+    def __str__(self) -> str:
         """Add info about expected input if available."""
         ex = "" if self.expected is None else ": expected " + self.expected
         return super().__str__() + ex
@@ -207,22 +206,22 @@ class InvalidXPath(ParserException):
 class NotSupported(ParserException):
     """Exception to be raised for unimplemented XPath features."""
 
-    def __init__(self: NotSupported, parser: Parser, feature: str):
+    def __init__(self, parser: "Parser", feature: str):
         super().__init__(parser)
         self.feature = feature
 
-    def __str__(self: NotSupported) -> str:
+    def __str__(self) -> str:
         return super().str() + ": " + str(self.feature)
 
 
 class MissingModule(YangsonException):
     """Abstract exception class – a module is missing."""
 
-    def __init__(self: MissingModule, name: YangIdentifier, rev: str = ""):
+    def __init__(self, name: YangIdentifier, rev: str = ""):
         self.name = name
         self.rev = rev
 
-    def __str__(self: MissingModule) -> str:
+    def __str__(self) -> str:
         if self.rev:
             return self.name + "@" + self.rev
         return self.name
@@ -231,21 +230,21 @@ class MissingModule(YangsonException):
 class MissingModuleNamespace(YangsonException):
     """Abstract exception class – a module is missing."""
 
-    def __init__(self: MissingModuleNamespace, ns: str):
+    def __init__(self, ns: str):
         self.ns = ns
 
-    def __str__(self: MissingModuleNamespace) -> str:
+    def __str__(self) -> str:
         return self.ns
 
 
 class ModuleContentMismatch(YangsonException):
     """Abstract exception class – unexpected module name or revision."""
 
-    def __init__(self: ModuleContentMismatch, found: YangIdentifier, expected: YangIdentifier):
+    def __init__(self, found: YangIdentifier, expected: YangIdentifier):
         self.found = found
         self.expected = expected
 
-    def __str__(self: ModuleContentMismatch) -> str:
+    def __str__(self) -> str:
         return f"'{self.found}', expected '{self.expected}'"
 
 
@@ -272,20 +271,20 @@ class ModuleNotImplemented(MissingModule):
 class BadYangLibraryData(YangsonException):
     """Broken YANG library data."""
 
-    def __init__(self: BadYangLibraryData, message: str):
+    def __init__(self, message: str):
         self.message = message
 
-    def __str__(self: BadYangLibraryData) -> str:
+    def __str__(self) -> str:
         return self.message
 
 
 class InvalidSchemaPath(YangsonException):
     """Invalid schema or data path."""
 
-    def __init__(self: InvalidSchemaPath, path: str):
+    def __init__(self, path: str):
         self.path = path
 
-    def __str__(self: InvalidSchemaPath) -> str:
+    def __str__(self) -> str:
         return self.path
 
 
@@ -300,53 +299,53 @@ class MissingAugmentTarget(YangsonException):
       ``import``.
     """
 
-    def __init__(self: MissingAugmentTarget, sni: str):
+    def __init__(self, sni: str):
         self.sni = sni
 
-    def __str__(self: MissingAugmentTarget) -> str:
+    def __str__(self) -> str:
         return self.sni
 
 
 class UnknownPrefix(YangsonException):
     """Unknown namespace prefix."""
 
-    def __init__(self: UnknownPrefix, prefix: YangIdentifier, mid: ModuleId):
+    def __init__(self, prefix: YangIdentifier, mid: ModuleId):
         self.prefix = prefix
         self.mid = mid
 
-    def __str__(self: UnknownPrefix) -> str:
+    def __str__(self) -> str:
         return f"prefix {self.prefix} is not defined in {self.mid}"
 
 
 class ModuleNotImported(YangsonException):
     """Module is not imported."""
 
-    def __init__(self: ModuleNotImported, mod: YangIdentifier, mid: ModuleId):
+    def __init__(self, mod: YangIdentifier, mid: ModuleId):
         self.mod = mod
         self.mid = mid
 
-    def __str__(self: ModuleNotImported) -> str:
+    def __str__(self) -> str:
         return f"{self.mod} not imported in {self.mid}"
 
 
 class FeaturePrerequisiteError(YangsonException):
     """Pre-requisite feature is not supported."""
 
-    def __init__(self: FeaturePrerequisiteError, name: YangIdentifier, ns: YangIdentifier):
+    def __init__(self, name: YangIdentifier, ns: YangIdentifier):
         self.name = name
         self.ns = ns
 
-    def __str__(self: FeaturePrerequisiteError) -> str:
+    def __str__(self) -> str:
         return f"{self.ns}:{self.name}"
 
 
 class MultipleImplementedRevisions(YangsonException):
     """A module has multiple implemented revisions."""
 
-    def __init__(self: MultipleImplementedRevisions, module: YangIdentifier):
+    def __init__(self, module: YangIdentifier):
         self.module = module
 
-    def __str__(self: MultipleImplementedRevisions) -> str:
+    def __str__(self) -> str:
         return self.module
 
 
@@ -357,23 +356,23 @@ class CyclicImports(YangsonException):
 class SchemaNodeException(YangsonException):
     """Abstract exception class for schema node errors."""
 
-    def __init__(self: SchemaNodeException, qn: QualName):
+    def __init__(self, qn: QualName):
         self.qn = qn
 
-    def __str__(self: SchemaNodeException) -> str:
+    def __str__(self) -> str:
         return "/" if self.qn[0] is None else f"{self.qn[1]}:{self.qn[0]}"
 
 
 class NonexistentSchemaNode(SchemaNodeException):
     """A schema node doesn't exist."""
 
-    def __init__(self: NonexistentSchemaNode, qn: QualName, name: YangIdentifier,
+    def __init__(self, qn: QualName, name: YangIdentifier,
                  ns: YangIdentifier = None):
         super().__init__(qn)
         self.name = name
         self.ns = ns
 
-    def __str__(self: NonexistentSchemaNode) -> str:
+    def __str__(self) -> str:
         prefix = "" if self.ns is None or self.ns == self.qn[1] else self.ns + ":"
         return f"{prefix}{self.name} under {super().__str__()}"
 
@@ -381,11 +380,11 @@ class NonexistentSchemaNode(SchemaNodeException):
 class BadSchemaNodeType(SchemaNodeException):
     """A schema node is of a wrong type."""
 
-    def __init__(self: BadSchemaNodeType, qn: QualName, expected: str):
+    def __init__(self, qn: QualName, expected: str):
         super().__init__(qn)
         self.expected = expected
 
-    def __str__(self: BadSchemaNodeType) -> str:
+    def __str__(self) -> str:
         return super().__str__() + " is not a " + self.expected
 
 
@@ -396,10 +395,10 @@ class InvalidLeafrefPath(SchemaNodeException):
 class RawDataError(YangsonException):
     """Abstract exception class for errors in raw data."""
 
-    def __init__(self: RawDataError, path: JSONPointer):
+    def __init__(self, path: JSONPointer):
         self.path = path
 
-    def __str__(self: RawDataError) -> JSONPointer:
+    def __str__(self) -> JSONPointer:
         return self.path
 
 
@@ -410,23 +409,23 @@ class RawMemberError(RawDataError):
 class RawTypeError(RawDataError):
     """Raw value is of an incorrect type."""
 
-    def __init__(self: RawTypeError, path: JSONPointer, expected: str):
+    def __init__(self, path: JSONPointer, expected: str):
         super().__init__(path)
         self.message = "expected " + expected
 
-    def __str__(self: RawTypeError):
+    def __str__(self):
         return f"[{self.path}] {self.message}"
 
 
 class ValidationError(YangsonException):
     """Abstract exception class for instance validation errors."""
 
-    def __init__(self: ValidationError, path: JSONPointer, tag: str, message: str = None):
+    def __init__(self, path: JSONPointer, tag: str, message: str = None):
         self.path = path
         self.tag = tag
         self.message = message
 
-    def __str__(self: ValidationError) -> str:
+    def __str__(self) -> str:
         msg = ": " + self.message if self.message else ""
         return f"[{self.path}] {self.tag}{msg}"
 
@@ -446,11 +445,11 @@ class YangTypeError(ValidationError):
 class StatementNotFound(YangsonException):
     """Required statement does not exist."""
 
-    def __init__(self: StatementNotFound, parent: PrefName, kw: YangIdentifier):
+    def __init__(self, parent: PrefName, kw: YangIdentifier):
         self.parent = parent
         self.keyword = kw
 
-    def __str__(self: StatementNotFound) -> str:
+    def __str__(self) -> str:
         """Print the statement's keyword."""
         return f"`{self.keyword}' in `{self.parent}'"
 
@@ -458,19 +457,19 @@ class StatementNotFound(YangsonException):
 class DefinitionNotFound(YangsonException):
     """Requested definition does not exist."""
 
-    def __init__(self: DefinitionNotFound, kw: YangIdentifier, name: YangIdentifier):
+    def __init__(self, kw: YangIdentifier, name: YangIdentifier):
         self.keyword = kw
         self.name = name
 
-    def __str__(self: DefinitionNotFound) -> str:
+    def __str__(self) -> str:
         return f"{self.keyword} {self.name}"
 
 
 class XPathTypeError(YangsonException):
     """The value of an XPath (sub)expression is of a wrong type."""
 
-    def __init__(self: XPathTypeError, value: str):
+    def __init__(self, value: str):
         self.value = value
 
-    def __str__(self: XPathTypeError) -> str:
+    def __str__(self) -> str:
         return self.value

--- a/yangson/instvalue.py
+++ b/yangson/instvalue.py
@@ -24,7 +24,6 @@ This module implements the following classes:
 * ObjectValue: Cooked object value of an instance node.
 """
 
-from __future__ import annotations
 from datetime import datetime
 from typing import Dict, List, Union
 from .typealiases import InstanceName, PrefName, ScalarValue
@@ -46,7 +45,7 @@ MetadataObject = Dict[PrefName, ScalarValue]
 class StructuredValue:
     """Abstract class for array and object values."""
 
-    def __init__(self: StructuredValue, ts: datetime):
+    def __init__(self, ts: datetime):
         """Initialize class instance.
 
         Args:
@@ -54,15 +53,15 @@ class StructuredValue:
         """
         self.timestamp = ts if ts else datetime.now()
 
-    def copy(self: StructuredValue) -> StructuredValue:
+    def copy(self) -> "StructuredValue":
         """Return a shallow copy of the receiver."""
         return self.__class__(super().copy(), datetime.now())
 
-    def __setitem__(self: StructuredValue, key: InstanceKey, value: Value) -> None:
+    def __setitem__(self, key: InstanceKey, value: Value) -> None:
         super().__setitem__(key, value)
         self.timestamp = datetime.now()
 
-    def __eq__(self: StructuredValue, val: StructuredValue) -> bool:
+    def __eq__(self, val: "StructuredValue") -> bool:
         """Return ``True`` if the receiver equal to `val`.
 
         Args:
@@ -70,7 +69,7 @@ class StructuredValue:
         """
         return self.__class__ == val.__class__ and hash(self) == hash(val)
 
-    def __hash__(self: StructuredValue) -> int:
+    def __hash__(self) -> int:
         """Return hash value for the receiver."""
         raise NotImplementedError()
 
@@ -78,11 +77,11 @@ class StructuredValue:
 class ArrayValue(StructuredValue, list):
     """This class represents cooked array values."""
 
-    def __init__(self: ArrayValue, val: List[EntryValue] = [], ts: datetime = None):
+    def __init__(self, val: List[EntryValue] = [], ts: datetime = None):
         StructuredValue.__init__(self, ts)
         list.__init__(self, val)
 
-    def __hash__(self: ArrayValue) -> int:
+    def __hash__(self) -> int:
         """Return hash value for the receiver."""
         return tuple([x.__hash__() for x in self]).__hash__()
 
@@ -90,12 +89,12 @@ class ArrayValue(StructuredValue, list):
 class ObjectValue(StructuredValue, dict):
     """This class represents cooked object values."""
 
-    def __init__(self: ObjectValue, val: Dict[InstanceName, Value] = {},
+    def __init__(self, val: Dict[InstanceName, Value] = {},
                  ts: datetime = None):
         StructuredValue.__init__(self, ts)
         dict.__init__(self, val)
 
-    def __hash__(self: ObjectValue) -> int:
+    def __hash__(self) -> int:
         """Return hash value for the receiver."""
         sks = sorted(self.keys())
         return tuple([(k, self[k].__hash__()) for k in sks]).__hash__()

--- a/yangson/nodeset.py
+++ b/yangson/nodeset.py
@@ -17,10 +17,14 @@
 
 """XPath node-set"""
 
-from __future__ import annotations
 from typing import Callable, Union
 from numbers import Number
 from .instance import InstanceNode
+
+# Type aliases
+
+NodeExpr = Callable[[InstanceNode], "NodeSet"]
+XPathValue = Union["NodeSet", str, float, bool]
 
 def comparison(meth):
     def wrap(self, arg):
@@ -37,24 +41,24 @@ def comparison(meth):
 
 class NodeSet(list):
 
-    def union(self: NodeSet, ns: NodeSet) -> NodeSet:
+    def union(self, ns: "NodeSet") -> "NodeSet":
         paths = set([n.path for n in self])
         return self.__class__(self + [n for n in ns if n.path not in paths])
 
-    def bind(self: NodeSet, trans: NodeExpr) -> NodeSet:
+    def bind(self, trans: NodeExpr) -> "NodeSet":
         res = self.__class__([])
         for n in self:
             res = res.union(trans(n))
         return res
 
-    def __float__(self: NodeSet) -> float:
+    def __float__(self) -> float:
         return float(self[0].value)
 
-    def __str__(self: NodeSet) -> str:
+    def __str__(self) -> str:
         return str(self[0]) if self else ""
 
     @comparison
-    def __eq__(self: NodeSet, val: XPathValue) -> bool:
+    def __eq__(self, val: XPathValue) -> bool:
         for n in self:
             if n.is_internal():
                 continue
@@ -69,7 +73,7 @@ class NodeSet(list):
         return False
 
     @comparison
-    def __ne__(self: NodeSet, val: XPathValue) -> bool:
+    def __ne__(self, val: XPathValue) -> bool:
         for n in self:
             if n.is_internal():
                 continue
@@ -84,7 +88,7 @@ class NodeSet(list):
         return False
 
     @comparison
-    def __gt__(self: NodeSet, val: XPathValue) -> bool:
+    def __gt__(self, val: XPathValue) -> bool:
         try:
             val = float(val)
         except (ValueError, TypeError):
@@ -98,7 +102,7 @@ class NodeSet(list):
         return False
 
     @comparison
-    def __lt__(self: NodeSet, val: XPathValue) -> bool:
+    def __lt__(self, val: XPathValue) -> bool:
         try:
             val = float(val)
         except (ValueError, TypeError):
@@ -112,7 +116,7 @@ class NodeSet(list):
         return False
 
     @comparison
-    def __ge__(self: NodeSet, val: XPathValue) -> bool:
+    def __ge__(self, val: XPathValue) -> bool:
         try:
             val = float(val)
         except (ValueError, TypeError):
@@ -126,7 +130,7 @@ class NodeSet(list):
         return False
 
     @comparison
-    def __le__(self: NodeSet, val: XPathValue) -> bool:
+    def __le__(self, val: XPathValue) -> bool:
         try:
             val = float(val)
         except (ValueError, TypeError):
@@ -138,8 +142,3 @@ class NodeSet(list):
             except (ValueError, TypeError):
                 continue
         return False
-
-# Type aliases
-
-NodeExpr = Callable[[InstanceNode], NodeSet]
-XPathValue = Union[NodeSet, str, float, bool]

--- a/yangson/parser.py
+++ b/yangson/parser.py
@@ -22,7 +22,6 @@ This module implements the following class:
 * Parser: Recursive-descent parser.
 """
 
-from __future__ import annotations
 import re
 from typing import Callable, List, Dict, Optional, Tuple
 from typing.re import Pattern
@@ -53,7 +52,7 @@ class Parser:
     ufloat_re = re.compile(fr"{_uint}(\.{_uint})?|\.{_uint}")
     """Regular expression for unsigned float."""
 
-    def __init__(self: Parser, text: str):
+    def __init__(self, text: str):
         """Initialize the class instance.
 
         Args:
@@ -64,24 +63,24 @@ class Parser:
         self.offset = 0  # type: int
         """Current position in the input text."""
 
-    def __str__(self: Parser) -> str:
+    def __str__(self) -> str:
         """Return string representation of the receiver's input text and state."""
         return self.input[:self.offset] + "§" + self.input[self.offset:]
 
-    def adv_skip_ws(self: Parser) -> bool:
+    def adv_skip_ws(self) -> bool:
         """Advance offset and skip optional whitespace."""
         self.offset += 1
         return self.skip_ws()
 
-    def at_end(self: Parser) -> bool:
+    def at_end(self) -> bool:
         """Return ``True`` if at end of input."""
         return self.offset >= len(self.input)
 
-    def at_last_char(self: Parser) -> bool:
+    def at_last_char(self) -> bool:
         """Return ``True`` if at last character of input."""
         return self.offset == (len(self.input) - 1)
 
-    def char(self: Parser, c: str) -> None:
+    def char(self, c: str) -> None:
         """Parse the specified character.
 
         Args:
@@ -96,7 +95,7 @@ class Parser:
         else:
             raise UnexpectedInput(self, f"char '{c}'")
 
-    def dfa(self: Parser, ttab: TransitionTable, init: int = 0) -> int:
+    def dfa(self, ttab: TransitionTable, init: int = 0) -> int:
         """Run a DFA and return the final (negative) state.
 
         Args:
@@ -115,14 +114,14 @@ class Parser:
                 return state
             self.offset += 1
 
-    def line_column(self: Parser) -> Tuple[int, int]:
+    def line_column(self) -> Tuple[int, int]:
         """Return line and column coordinates."""
         ln = self.input.count("\n", 0, self.offset)
         c = (self.offset if ln == 0 else
              self.offset - self.input.rfind("\n", 0, self.offset) - 1)
         return (ln + 1, c)
 
-    def match_regex(self: Parser, regex: Pattern, required: bool = False,
+    def match_regex(self, regex: Pattern, required: bool = False,
                     meaning: str = "") -> str:
         """Parse input based on a regular expression .
 
@@ -141,7 +140,7 @@ class Parser:
         if required:
             raise UnexpectedInput(self, meaning)
 
-    def one_of(self: Parser, chset: str) -> str:
+    def one_of(self, chset: str) -> str:
         """Parse one character form the specified set.
 
         Args:
@@ -159,7 +158,7 @@ class Parser:
             return res
         raise UnexpectedInput(self, "one of " + chset)
 
-    def peek(self: Parser) -> str:
+    def peek(self) -> str:
         """Return the next character without advancing offset.
 
         Raises:
@@ -170,7 +169,7 @@ class Parser:
         except IndexError:
             raise EndOfInput(self)
 
-    def prefixed_name(self: Parser) -> Tuple[YangIdentifier, Optional[YangIdentifier]]:
+    def prefixed_name(self) -> Tuple[YangIdentifier, Optional[YangIdentifier]]:
         """Parse identifier with an optional colon-separated prefix."""
         i1 = self.yang_identifier()
         try:
@@ -182,17 +181,17 @@ class Parser:
         self.offset += 1
         return (self.yang_identifier(), i1)
 
-    def remaining(self: Parser) -> str:
+    def remaining(self) -> str:
         """Return the remaining part of the input string."""
         res = self.input[self.offset:]
         self.offset = len(self.input)
         return res
 
-    def skip_ws(self: Parser) -> bool:
+    def skip_ws(self) -> bool:
         """Skip optional whitespace."""
         return len(self.match_regex(self.ws_re)) > 0
 
-    def test_string(self: Parser, string: str) -> bool:
+    def test_string(self, string: str) -> bool:
         """If `string` comes next, return ``True`` and advance offset.
 
         Args:
@@ -203,15 +202,15 @@ class Parser:
             return True
         return False
 
-    def unsigned_integer(self: Parser) -> int:
+    def unsigned_integer(self) -> int:
         """Parse and return an unsigned integer."""
         return int(self.match_regex(self.uint_re, True, "unsigned integer"))
 
-    def unsigned_float(self: Parser) -> float:
+    def unsigned_float(self) -> float:
         """Parse and return unsigned floating-point number."""
         return float(self.match_regex(self.ufloat_re, True, "unsigned float"))
 
-    def up_to(self: Parser, term: str) -> str:
+    def up_to(self, term: str) -> str:
         """Parse and return segment terminated by the first occurence of a string.
 
         Args:
@@ -227,7 +226,7 @@ class Parser:
         self.offset = end + 1
         return res
 
-    def yang_identifier(self: Parser) -> YangIdentifier:
+    def yang_identifier(self) -> YangIdentifier:
         """Parse and return YANG identifier.
 
         Raises:

--- a/yangson/schemadata.py
+++ b/yangson/schemadata.py
@@ -26,7 +26,6 @@ This module implements the following classes:
 * FeatureExprParser: Parser for if-feature expressions.
 """
 
-from __future__ import annotations
 from typing import Any, Dict, List, MutableSet, Tuple
 from .exceptions import (
     InvalidSchemaPath, BadYangLibraryData, CyclicImports, DefinitionNotFound,
@@ -44,7 +43,7 @@ if False:                       # fake import for type aliases
 class IdentityAdjacency:
     """Adjacency data for an identity."""
 
-    def __init__(self: IdentityAdjacency):
+    def __init__(self):
         self.bases = set()  # type: MutableSet[QualName]
         self.derivs = set()  # type: MutableSet[QualName]
 
@@ -52,7 +51,7 @@ class IdentityAdjacency:
 class SchemaContext:
     """Schema data and current schema context."""
 
-    def __init__(self: SchemaContext, schema_data: SchemaData, default_ns: YangIdentifier,
+    def __init__(self, schema_data: "SchemaData", default_ns: YangIdentifier,
                  text_mid: ModuleId):
         """Initialize the class instance."""
         self.schema_data = schema_data
@@ -65,7 +64,7 @@ class SchemaContext:
 class ModuleData:
     """Data related to a YANG module or submodule."""
 
-    def __init__(self: ModuleData, main_module: YangIdentifier, yang_id: YangIdentifier):
+    def __init__(self, main_module: YangIdentifier, yang_id: YangIdentifier):
         """Initialize the class instance."""
         self.features = set()  # type: MutableSet[YangIdentifier]
         """Set of supported features."""
@@ -94,7 +93,7 @@ class SchemaData:
             mod_path: List of directories to search for YANG modules.
     """
 
-    def __init__(self: SchemaData, yang_lib: Dict[str, Any], mod_path: List[str]) -> None:
+    def __init__(self, yang_lib: Dict[str, Any], mod_path: List[str]) -> None:
         """Initialize the schema structures."""
         self.identity_adjs = {}  # type: Dict[QualName, IdentityAdjacency]
         """Dictionary of identity bases."""
@@ -111,7 +110,7 @@ class SchemaData:
         """List that defines the order of module processing."""
         self._from_yang_library(yang_lib)
 
-    def _from_yang_library(self: SchemaData, yang_lib: Dict[str, Any]) -> None:
+    def _from_yang_library(self, yang_lib: Dict[str, Any]) -> None:
         """Set the schema structures from YANG library data.
 
         Args:
@@ -167,7 +166,7 @@ class SchemaData:
         self._process_imports()
         self._check_feature_dependences()
 
-    def _load_module(self: SchemaData, name: YangIdentifier,
+    def _load_module(self, name: YangIdentifier,
                      rev: RevisionDate, mdata: ModuleData) -> Statement:
         """Read and parse a YANG module or submodule."""
         for d in self.module_search_path:
@@ -187,7 +186,7 @@ class SchemaData:
                 return res
         raise ModuleNotFound(name, rev)
 
-    def _process_imports(self: SchemaData) -> None:
+    def _process_imports(self) -> None:
         impl = set(self.implement.items())
         if len(impl) == 0:
             return
@@ -224,7 +223,7 @@ class SchemaData:
         if [mid for mid in deps if len(deps[mid]) > 0]:
             raise CyclicImports()
 
-    def _check_feature_dependences(self: SchemaData):
+    def _check_feature_dependences(self):
         """Verify feature dependences."""
         for mid in self.modules:
             for fst in self.modules[mid].statement.find_all("feature"):
@@ -234,7 +233,7 @@ class SchemaData:
                 if not self.if_features(fst, mid):
                     raise FeaturePrerequisiteError(fn, fid[0])
 
-    def namespace(self: SchemaData, mid: ModuleId) -> YangIdentifier:
+    def namespace(self, mid: ModuleId) -> YangIdentifier:
         """Return the namespace corresponding to a module or submodule.
 
         Args:
@@ -249,7 +248,7 @@ class SchemaData:
             raise ModuleNotRegistered(*mid) from None
         return mdata.main_module[0]
 
-    def last_revision(self: SchemaData, mod: YangIdentifier) -> ModuleId:
+    def last_revision(self, mod: YangIdentifier) -> ModuleId:
         """Return the last revision of a module that's part of the data model.
 
         Args:
@@ -264,7 +263,7 @@ class SchemaData:
             raise ModuleNotRegistered(mod)
         return sorted(revs, key=lambda x: x[1])[-1]
 
-    def prefix2ns(self: SchemaData, prefix: YangIdentifier, mid: ModuleId) -> YangIdentifier:
+    def prefix2ns(self, prefix: YangIdentifier, mid: ModuleId) -> YangIdentifier:
         """Return the namespace corresponding to a prefix.
 
         Args:
@@ -284,7 +283,7 @@ class SchemaData:
         except KeyError:
             raise UnknownPrefix(prefix, mid) from None
 
-    def resolve_pname(self: SchemaData, pname: PrefName,
+    def resolve_pname(self, pname: PrefName,
                       mid: ModuleId) -> Tuple[YangIdentifier, ModuleId]:
         """Return the name and module identifier in which the name is defined.
 
@@ -306,7 +305,7 @@ class SchemaData:
         except KeyError:
             raise UnknownPrefix(p, mid) from None
 
-    def translate_pname(self: SchemaData, pname: PrefName, mid: ModuleId) -> QualName:
+    def translate_pname(self, pname: PrefName, mid: ModuleId) -> QualName:
         """Translate a prefixed name to a qualified name.
         Args:
             pname: Name with an optional prefix.
@@ -318,7 +317,7 @@ class SchemaData:
         loc, nid = self.resolve_pname(pname, mid)
         return (loc, self.namespace(nid))
 
-    def translate_node_id(self: SchemaData, ni: PrefName, sctx: SchemaContext) -> QualName:
+    def translate_node_id(self, ni: PrefName, sctx: SchemaContext) -> QualName:
         """Translate node identifier to a qualified name.
 
         Args:
@@ -341,7 +340,7 @@ class SchemaData:
         except KeyError:
             raise UnknownPrefix(p, sctx.text_mid) from None
 
-    def prefix(self: SchemaData, imod: YangIdentifier, mid: ModuleId) -> YangIdentifier:
+    def prefix(self, imod: YangIdentifier, mid: ModuleId) -> YangIdentifier:
         """Return the prefix corresponding to an implemented module.
 
         Args:
@@ -366,7 +365,7 @@ class SchemaData:
                 return p
         raise ModuleNotImported(imod, mid)
 
-    def sni2route(self: SchemaData, sni: SchemaNodeId, sctx: SchemaContext) -> SchemaRoute:
+    def sni2route(self, sni: SchemaNodeId, sctx: SchemaContext) -> SchemaRoute:
         """Translate schema node identifier to a schema route.
 
         Args:
@@ -411,7 +410,7 @@ class SchemaData:
                 raise InvalidSchemaPath(path)
         return res
 
-    def get_definition(self: SchemaData, stmt: Statement,
+    def get_definition(self, stmt: Statement,
                        sctx: SchemaContext) -> Tuple[Statement, SchemaContext]:
         """Find the statement defining a grouping or derived type.
 
@@ -452,7 +451,7 @@ class SchemaData:
                     dstmt, SchemaContext(sctx.schema_data, sctx.default_ns, sid))
         raise DefinitionNotFound(kw, stmt.argument)
 
-    def is_derived_from(self: SchemaData, identity: QualName, base: QualName) -> bool:
+    def is_derived_from(self, identity: QualName, base: QualName) -> bool:
         """Return ``True`` if `identity` is derived from `base`."""
         try:
             bases = self.identity_adjs[identity].bases
@@ -465,7 +464,7 @@ class SchemaData:
                 return True
         return False
 
-    def derived_from(self: SchemaData, identity: QualName) -> MutableSet[QualName]:
+    def derived_from(self, identity: QualName) -> MutableSet[QualName]:
         """Return list of identities transitively derived from `identity`."""
         try:
             res = self.identity_adjs[identity].derivs
@@ -475,7 +474,7 @@ class SchemaData:
             res |= self.derived_from(id)
         return res
 
-    def derived_from_all(self: SchemaData, identities: List[QualName]) -> MutableSet[QualName]:
+    def derived_from_all(self, identities: List[QualName]) -> MutableSet[QualName]:
         """Return list of identities transitively derived from all `identity`."""
         if not identities:
             return set()
@@ -484,7 +483,7 @@ class SchemaData:
             res &= self.derived_from(id)
         return res
 
-    def if_features(self: SchemaData, stmt: Statement, mid: ModuleId) -> bool:
+    def if_features(self, stmt: Statement, mid: ModuleId) -> bool:
         """Evaluate ``if-feature`` substatements on a statement, if any.
 
         Args:
@@ -510,7 +509,7 @@ class SchemaData:
 class FeatureExprParser(Parser):
     """Parser and evaluator for if-feature expressions."""
 
-    def __init__(self: FeatureExprParser, text: str, schema_data: SchemaData, mid: ModuleId):
+    def __init__(self, text: str, schema_data: SchemaData, mid: ModuleId):
         """Initialize the parser instance.
 
         Args:
@@ -525,7 +524,7 @@ class FeatureExprParser(Parser):
         self.mid = mid
         self.schema_data = schema_data
 
-    def parse(self: FeatureExprParser) -> bool:
+    def parse(self) -> bool:
         """Parse and evaluate a complete feature expression.
 
         Raises:
@@ -540,7 +539,7 @@ class FeatureExprParser(Parser):
             raise InvalidFeatureExpression(self)
         return res
 
-    def _feature_disj(self: FeatureExprParser) -> bool:
+    def _feature_disj(self) -> bool:
         x = self._feature_conj()
         if self.test_string("or"):
             if not self.skip_ws():
@@ -548,7 +547,7 @@ class FeatureExprParser(Parser):
             return self._feature_disj() or x
         return x
 
-    def _feature_conj(self: FeatureExprParser) -> bool:
+    def _feature_conj(self) -> bool:
         x = self._feature_term()
         if self.test_string("and"):
             if not self.skip_ws():
@@ -556,14 +555,14 @@ class FeatureExprParser(Parser):
             return self._feature_conj() and x
         return x
 
-    def _feature_term(self: FeatureExprParser) -> bool:
+    def _feature_term(self) -> bool:
         if self.test_string("not"):
             if not self.skip_ws():
                 raise InvalidFeatureExpression(self)
             return not self._feature_atom()
         return self._feature_atom()
 
-    def _feature_atom(self: FeatureExprParser) -> bool:
+    def _feature_atom(self) -> bool:
         if self.peek() == "(":
             self.adv_skip_ws()
             res = self._feature_disj()

--- a/yangson/schpattern.py
+++ b/yangson/schpattern.py
@@ -17,7 +17,6 @@
 
 """This module defines classes for schema patterns."""
 
-from __future__ import annotations
 from typing import List, Optional, TYPE_CHECKING
 from .enumerations import ContentType
 from .typealiases import InstanceName, _Singleton, YangIdentifier
@@ -30,162 +29,162 @@ class SchemaPattern:
     """Abstract class for schema patterns."""
 
     @staticmethod
-    def optional(p: SchemaPattern) -> SchemaPattern:
+    def optional(p: "SchemaPattern") -> "SchemaPattern":
         """Make `p` an optional pattern."""
         return Alternative.combine(Empty(), p)
 
-    def nullable(self: SchemaPattern, ctype: ContentType) -> bool:
+    def nullable(self, ctype: ContentType) -> bool:
         """Return ``True`` the receiver is nullable."""
         return False
 
-    def empty(self: SchemaPattern) -> bool:
+    def empty(self) -> bool:
         """Return ``True`` if the receiver is (conditionally) empty."""
         return False
 
-    def _active(self: SchemaPattern, ctype: ContentType) -> bool:
+    def _active(self, ctype: ContentType) -> bool:
         """Return ``True`` the receiver is active in the current context."""
         return True
 
-    def _eval_when(self: SchemaPattern, cnode: InstanceNode) -> None:
+    def _eval_when(self, cnode: "InstanceNode") -> None:
         return
 
-    def _mandatory_members(self: SchemaPattern, ctype: ContentType) -> List[InstanceName]:
+    def _mandatory_members(self, ctype: ContentType) -> List[InstanceName]:
         return []
 
 
 class Empty(SchemaPattern, metaclass=_Singleton):
     """Singleton class representing the empty pattern."""
 
-    def nullable(self: Empty, ctype: ContentType) -> bool:
+    def nullable(self, ctype: ContentType) -> bool:
         """Override the superclass method."""
         return True
 
-    def deriv(self: Empty, x: str, ctype: ContentType) -> SchemaPattern:
+    def deriv(self, x: str, ctype: ContentType) -> SchemaPattern:
         """Return derivative of the receiver."""
         return NotAllowed()
 
-    def empty(self: Empty) -> bool:
+    def empty(self) -> bool:
         """Override the superclass method."""
         return True
 
-    def tree(self: Empty, indent: int = 0):
+    def tree(self, indent: int = 0):
         return " " * indent + "Empty"
 
-    def __str__(self: Empty) -> str:
+    def __str__(self) -> str:
         return "Empty"
 
 
 class NotAllowed(SchemaPattern, metaclass=_Singleton):
 
-    def deriv(self: NotAllowed, x: str, ctype: ContentType) -> SchemaPattern:
+    def deriv(self, x: str, ctype: ContentType) -> SchemaPattern:
         """Return derivative of the receiver."""
         return self
 
-    def tree(self: NotAllowed, indent: int = 0):
+    def tree(self, indent: int = 0):
         return " " * indent + "NotAllowed"
 
-    def __str__(self: NotAllowed) -> str:
+    def __str__(self) -> str:
         return "NotAllowed"
 
 
 class Conditional(SchemaPattern):
     """Class representing conditional pattern."""
 
-    def __init__(self: Conditional, when: Expr):
+    def __init__(self, when: Expr):
         """Initialize the class instance."""
         self.when = when
         self._val_when = None  # type: bool
 
-    def empty(self: Conditional) -> bool:
+    def empty(self) -> bool:
         """Override the superclass method."""
         return self.when and not self._val_when
 
-    def check_when(self: Conditional) -> bool:
+    def check_when(self) -> bool:
         return not self.when or self._val_when
 
-    def _eval_when(self: Conditional, cnode: InstanceNode) -> None:
+    def _eval_when(self, cnode: "InstanceNode") -> None:
         self._val_when = bool(self.when.evaluate(cnode))
 
-    def _active(self: Conditional, ctype: ContentType) -> bool:
+    def _active(self, ctype: ContentType) -> bool:
         return super()._active(ctype) and self.check_when()
 
 
 class Typeable(SchemaPattern):
     """Multiple content types and their combinations."""
 
-    def __init__(self: Typeable, ctype: ContentType):
+    def __init__(self, ctype: ContentType):
         """Initialize the class instance."""
         self.ctype = ctype
 
-    def match_ctype(self: Typeable, ctype) -> bool:
+    def match_ctype(self, ctype) -> bool:
         return self.ctype.value & ctype.value != 0
 
-    def _active(self: Typeable, ctype: ContentType) -> bool:
+    def _active(self, ctype: ContentType) -> bool:
         return super()._active(ctype) and self.match_ctype(ctype)
 
 
 class ConditionalPattern(Conditional):
     """Class representing conditional pattern."""
 
-    def __init__(self: ConditionalPattern, p: SchemaPattern, when: Expr):
+    def __init__(self, p: SchemaPattern, when: Expr):
         """Initialize the class instance."""
         super().__init__(when)
         self.pattern = p
 
-    def _eval_when(self: ConditionalPattern, cnode: InstanceNode) -> None:
+    def _eval_when(self, cnode: "InstanceNode") -> None:
         super()._eval_when(cnode)
         self.pattern._eval_when(cnode)
 
-    def nullable(self: ConditionalPattern, ctype: ContentType) -> bool:
+    def nullable(self, ctype: ContentType) -> bool:
         """Override the superclass method."""
         return (not self.check_when() or self.pattern.nullable(ctype))
 
-    def deriv(self: ConditionalPattern, x: str, ctype: ContentType) -> SchemaPattern:
+    def deriv(self, x: str, ctype: ContentType) -> SchemaPattern:
         """Return derivative of the receiver."""
         return (self.pattern.deriv(x, ctype) if self.check_when() else
                 NotAllowed())
 
-    def tree(self: ConditionalPattern, indent: int = 0):
+    def tree(self, indent: int = 0):
         return (" " * indent + "Conditional\n" +
                 self.pattern.tree(indent + 2))
 
-    def __str__(self: ConditionalPattern) -> str:
+    def __str__(self) -> str:
         return str(self.pattern)
 
-    def _mandatory_members(self: ConditionalPattern, ctype: ContentType) -> List[InstanceName]:
+    def _mandatory_members(self, ctype: ContentType) -> List[InstanceName]:
         return self.pattern._mandatory_members(ctype) if self._active(ctype) else []
 
 
 class Member(Typeable, Conditional):
 
-    def __init__(self: Member, name: InstanceName, ctype: ContentType,
+    def __init__(self, name: InstanceName, ctype: ContentType,
                  when: Optional[Expr]):
         Typeable.__init__(self, ctype)
         Conditional.__init__(self, when)
         self.name = name
 
-    def _eval_when(self: Member, cnode: InstanceNode) -> None:
+    def _eval_when(self, cnode: "InstanceNode") -> None:
         if self.when:
             dummy = cnode.put_member(self.name, (None,))
             super()._eval_when(dummy)
 
-    def nullable(self: Member, ctype: ContentType) -> bool:
+    def nullable(self, ctype: ContentType) -> bool:
         """Override the superclass method."""
         return not (self._active(ctype))
 
-    def deriv(self: Member, x: str, ctype: ContentType) -> SchemaPattern:
+    def deriv(self, x: str, ctype: ContentType) -> SchemaPattern:
         """Return derivative of the receiver."""
         return (Empty() if
                 self.name == x and self._active(ctype)
                 else NotAllowed())
 
-    def tree(self: Member, indent: int = 0):
+    def tree(self, indent: int = 0):
         return " " * indent + "Member " + self.name
 
-    def __str__(self: Member) -> str:
+    def __str__(self) -> str:
         return f"member '{self.name}'"
 
-    def _mandatory_members(self: Member, ctype: ContentType) -> List[InstanceName]:
+    def _mandatory_members(self, ctype: ContentType) -> List[InstanceName]:
         return [self.name] if self._active(ctype) else []
 
 
@@ -199,33 +198,33 @@ class Alternative(SchemaPattern):
             return p
         return cls(p, q)
 
-    def __init__(self: Alternative, p: SchemaPattern, q: SchemaPattern):
+    def __init__(self, p: SchemaPattern, q: SchemaPattern):
         self.left = p
         self.right = q
 
-    def _eval_when(self: Alternative, cnode: InstanceNode) -> None:
+    def _eval_when(self, cnode: "InstanceNode") -> None:
         super()._eval_when(cnode)
         self.left._eval_when(cnode)
         self.right._eval_when(cnode)
 
-    def nullable(self: Alternative, ctype: ContentType) -> bool:
+    def nullable(self, ctype: ContentType) -> bool:
         """Override the superclass method."""
         return self.left.nullable(ctype) or self.right.nullable(ctype)
 
-    def deriv(self: Alternative, x: str, ctype: ContentType) -> SchemaPattern:
+    def deriv(self, x: str, ctype: ContentType) -> SchemaPattern:
         """Return derivative of the receiver."""
         return Alternative.combine(self.left.deriv(x, ctype),
                                    self.right.deriv(x, ctype))
 
-    def tree(self: Alternative, indent: int = 0):
+    def tree(self, indent: int = 0):
         return (" " * indent + "Alternative\n" +
                 self.left.tree(indent + 2) + "\n" +
                 self.right.tree(indent + 2))
 
-    def __str__(self: Alternative) -> str:
+    def __str__(self) -> str:
         return f"{self.left!s} or {self.right!s}"
 
-    def _mandatory_members(self: Alternative, ctype: ContentType) -> List[InstanceName]:
+    def _mandatory_members(self, ctype: ContentType) -> List[InstanceName]:
         lm = self.left._mandatory_members(ctype)
         rm = self.right._mandatory_members(ctype)
         return [] if not lm or not rm else lm + rm
@@ -233,25 +232,25 @@ class Alternative(SchemaPattern):
 
 class ChoicePattern(Alternative, Typeable):
 
-    def __init__(self: ChoicePattern, p: SchemaPattern, q: SchemaPattern,
+    def __init__(self, p: SchemaPattern, q: SchemaPattern,
                  name: YangIdentifier):
         super().__init__(p, q)
         self.ctype = ContentType.all  # type: ContentType
         self.name = name
 
-    def nullable(self: ChoicePattern, ctype: ContentType):
+    def nullable(self, ctype: ContentType):
         return not self.match_ctype(ctype)
 
-    def deriv(self: ChoicePattern, x: str, ctype: ContentType):
+    def deriv(self, x: str, ctype: ContentType):
         return (super().deriv(x, ctype) if self.match_ctype(ctype) else
                 NotAllowed())
 
-    def tree(self: ChoicePattern, indent: int = 0):
+    def tree(self, indent: int = 0):
         return (" " * indent +
                 f"Choice {self.name}\n{self.left.tree(indent + 2)}\n"
                 f"{self.right.tree(indent + 2)}")
 
-    def _members(self: ChoicePattern, ctype: ContentType) -> List[InstanceName]:
+    def _members(self, ctype: ContentType) -> List[InstanceName]:
         return super()._members(ctype) if self._active(ctype) else []
 
 
@@ -269,32 +268,32 @@ class Pair(SchemaPattern):
             return q
         return cls(p, q)
 
-    def __init__(self: Pair, p: SchemaPattern, q: SchemaPattern):
+    def __init__(self, p: SchemaPattern, q: SchemaPattern):
         self.left = p
         self.right = q
 
-    def nullable(self: Pair, ctype: ContentType) -> bool:
+    def nullable(self, ctype: ContentType) -> bool:
         """Override the superclass method."""
         return (self.left.nullable(ctype) and
                 self.right.nullable(ctype))
 
-    def deriv(self: Pair, x: str, ctype: ContentType) -> SchemaPattern:
+    def deriv(self, x: str, ctype: ContentType) -> SchemaPattern:
         """Return derivative of the receiver."""
         return Alternative.combine(
             Pair.combine(self.left.deriv(x, ctype), self.right),
             Pair.combine(self.right.deriv(x, ctype), self.left))
 
-    def _eval_when(self: Pair, cnode: InstanceNode) -> None:
+    def _eval_when(self, cnode: "InstanceNode") -> None:
         self.left._eval_when(cnode)
         self.right._eval_when(cnode)
 
-    def tree(self: Pair, indent: int = 0):
+    def tree(self, indent: int = 0):
         return (" " * indent + "Pair\n" +
                 self.left.tree(indent + 2) + "\n" +
                 self.right.tree(indent + 2))
 
-    def __str__(self: Pair) -> str:
+    def __str__(self) -> str:
         return str(self.left)
 
-    def _mandatory_members(self: Pair, ctype: ContentType) -> List[InstanceName]:
+    def _mandatory_members(self, ctype: ContentType) -> List[InstanceName]:
         return self.left._mandatory_members(ctype) + self.right._mandatory_members(ctype)

--- a/yangson/statement.py
+++ b/yangson/statement.py
@@ -23,7 +23,6 @@ This module implements the following classes:
 * Statement: YANG statements.
 """
 
-from __future__ import annotations
 from typing import List, Optional, Tuple
 from .exceptions import (
     EndOfInput, StatementNotFound, UnexpectedInput, InvalidArgument,
@@ -39,7 +38,7 @@ class Statement:
     _escape_table = str.maketrans({'"': '\\"', '\\': '\\\\'})
     """Table for translating characters to their escaped form."""
 
-    def __init__(self: Statement,
+    def __init__(self,
                  kw: YangIdentifier,
                  arg: Optional[str],
                  pref: YangIdentifier = None):
@@ -58,7 +57,7 @@ class Statement:
         self.superstmt = None
         self.substatements = []
 
-    def __str__(self: Statement) -> str:
+    def __str__(self) -> str:
         """Return string representation of the receiver.
         """
         kw = (self.keyword if self.prefix is None
@@ -68,7 +67,7 @@ class Statement:
         rest = " { ... }" if self.substatements else ";"
         return kw + arg + rest
 
-    def find1(self: Statement, kw: YangIdentifier, arg: str = None,
+    def find1(self, kw: YangIdentifier, arg: str = None,
               pref: YangIdentifier = None,
               required: bool = False) -> Optional["Statement"]:
         """Return first substatement with the given parameters.
@@ -90,7 +89,7 @@ class Statement:
         if required:
             raise StatementNotFound(str(self), kw)
 
-    def find_all(self: Statement, kw: YangIdentifier,
+    def find_all(self, kw: YangIdentifier,
                  pref: YangIdentifier = None) -> List["Statement"]:
         """Return the list all substatements with the given keyword and prefix.
 
@@ -101,7 +100,7 @@ class Statement:
         return [c for c in self.substatements
                 if c.keyword == kw and c.prefix == pref]
 
-    def get_definition(self: Statement, name: YangIdentifier,
+    def get_definition(self, name: YangIdentifier,
                        kw: YangIdentifier) -> Optional["Statement"]:
         """Search ancestor statements for a definition.
 
@@ -120,7 +119,7 @@ class Statement:
             stmt = stmt.superstmt
         return None
 
-    def get_error_info(self: Statement) -> Tuple[Optional[str], Optional[str]]:
+    def get_error_info(self) -> Tuple[Optional[str], Optional[str]]:
         """Return receiver's error tag and error message if present."""
         etag = self.find1("error-app-tag")
         emsg = self.find1("error-message")
@@ -134,7 +133,7 @@ class ModuleParser(Parser):
                     "\\": "\\"}  # type: Dict[str,str]
     """Dictionary for mapping escape sequences to characters."""
 
-    def __init__(self: ModuleParser, text: str, name: YangIdentifier = None, rev: str = None):
+    def __init__(self, text: str, name: YangIdentifier = None, rev: str = None):
         """Initialize the parser instance.
 
         Args:
@@ -145,7 +144,7 @@ class ModuleParser(Parser):
         self.name = name
         self.rev = rev
 
-    def parse(self: ModuleParser) -> Statement:
+    def parse(self) -> Statement:
         """Parse a complete YANG module or submodule.
 
         Args:
@@ -175,7 +174,7 @@ class ModuleParser(Parser):
             return res
         raise UnexpectedInput(self, "end of input")
 
-    def _back_break(self: ModuleParser) -> int:
+    def _back_break(self) -> int:
         self.offset -= 1
         return -1
 
@@ -194,7 +193,7 @@ class ModuleParser(Parser):
         except KeyError:
             raise InvalidArgument(text) from None
 
-    def opt_separator(self: ModuleParser) -> bool:
+    def opt_separator(self) -> bool:
         """Parse an optional separator and return ``True`` if found.
 
         Raises:
@@ -234,7 +233,7 @@ class ModuleParser(Parser):
             }])
         return start < self.offset
 
-    def separator(self: ModuleParser) -> None:
+    def separator(self) -> None:
         """Parse a mandatory separator.
 
         Raises:
@@ -245,7 +244,7 @@ class ModuleParser(Parser):
         if not present:
             raise UnexpectedInput(self, "separator")
 
-    def keyword(self: ModuleParser) -> Tuple[Optional[str], str]:
+    def keyword(self) -> Tuple[Optional[str], str]:
         """Parse a YANG statement keyword.
 
         Raises:
@@ -259,7 +258,7 @@ class ModuleParser(Parser):
             return (i1, i2)
         return (None, i1)
 
-    def statement(self: ModuleParser) -> Statement:
+    def statement(self) -> Statement:
         """Parse YANG statement.
 
         Raises:
@@ -289,7 +288,7 @@ class ModuleParser(Parser):
                 sub.superstmt = res
         return res
 
-    def argument(self: ModuleParser) -> bool:
+    def argument(self) -> bool:
         """Parse statement argument.
 
         Return ``True`` if the argument is followed by block of substatements.
@@ -320,7 +319,7 @@ class ModuleParser(Parser):
             raise UnexpectedInput(self, "';', '{'" +
                                   (" or '+'" if quoted else ""))
 
-    def sq_argument(self: ModuleParser) -> str:
+    def sq_argument(self) -> str:
         """Parse single-quoted argument.
 
         Raises:
@@ -329,7 +328,7 @@ class ModuleParser(Parser):
         self.offset += 1
         self._arg += self.up_to("'")
 
-    def dq_argument(self: ModuleParser) -> str:
+    def dq_argument(self) -> str:
         """Parse double-quoted argument.
 
         Raises:
@@ -354,7 +353,7 @@ class ModuleParser(Parser):
                       if self._escape else self.input[start:self.offset])
         self.offset += 1
 
-    def unq_argument(self: ModuleParser) -> str:
+    def unq_argument(self) -> str:
         """Parse unquoted argument.
 
         Raises:
@@ -379,7 +378,7 @@ class ModuleParser(Parser):
             }])
         self._arg = self.input[start:self.offset]
 
-    def substatements(self: ModuleParser) -> List[Statement]:
+    def substatements(self) -> List[Statement]:
         """Parse substatements.
 
         Raises:

--- a/yangson/xmlparser.py
+++ b/yangson/xmlparser.py
@@ -18,7 +18,6 @@
 """Extended XML parser that preserves the xmlns attributes
 """
 
-from __future__ import annotations
 import xml.etree.ElementTree as ET
 
 
@@ -27,7 +26,7 @@ class XMLParser(ET.XMLPullParser):
     Extended XML parser that add namespaces to ELements as
     xmlns/xmlns:... attributes
     '''
-    def __init__(self: XMLParser, source: str = None):
+    def __init__(self, source: str = None):
         '''
         Initialize the XML parser
 
@@ -44,7 +43,7 @@ class XMLParser(ET.XMLPullParser):
             self.close()
             self.parse()
 
-    def parse(self: XMLParser):
+    def parse(self):
         '''Parse all events in current available data'''
         for ev_type, ev_data in self.read_events():
             if ev_type == 'start-ns':
@@ -61,7 +60,7 @@ class XMLParser(ET.XMLPullParser):
                     ev_data.attrib[attr] = ns_url
 
     @property
-    def root(self: XMLParser):
+    def root(self):
         '''Return root node
 
         Only valid if the first event has been parsed'''

--- a/yangson/xpathast.py
+++ b/yangson/xpathast.py
@@ -24,7 +24,6 @@ class is intended to be public:
 * Expr: XPath 1.0 expression with YANG 1.1 extensions.
 """
 
-from __future__ import annotations
 import decimal
 from math import ceil, copysign, floor
 from pyxb.utils.xmlre import XMLToPython, RegularExpressionError
@@ -42,14 +41,14 @@ from .typealiases import QualName
 
 class XPathContext:
 
-    def __init__(self: XPathContext, cnode: InstanceNode, origin: InstanceNode,
+    def __init__(self, cnode: InstanceNode, origin: InstanceNode,
                  position: int, size: int):
         self.cnode = cnode
         self.origin = origin
         self.position = position
         self.size = size
 
-    def update_cnode(self: XPathContext, new_cnode: InstanceNode) -> "XPathContext":
+    def update_cnode(self, new_cnode: InstanceNode) -> "XPathContext":
         return self.__class__(new_cnode, self.origin, self.position, self.size)
 
 
@@ -59,11 +58,11 @@ class Expr:
     indent = 2
     _precedence = 8
 
-    def __str__(self: Expr) -> str:
+    def __str__(self) -> str:
         """Return a string representation of the receiver."""
         raise NotImplementedError
 
-    def evaluate(self: Expr, node: InstanceNode) -> XPathValue:
+    def evaluate(self, node: InstanceNode) -> XPathValue:
         """Evaluate the receiver and return the result.
 
         Args:
@@ -75,14 +74,14 @@ class Expr:
         """
         return self._eval(XPathContext(node, node, 1, 1))
 
-    def _eval_float(self: Expr, xctx: XPathContext) -> float:
+    def _eval_float(self, xctx: XPathContext) -> float:
         val = self._eval(xctx)
         try:
             return float(val)
         except ValueError:
             return float('nan')
 
-    def _eval_string(self: Expr, xctx: XPathContext) -> str:
+    def _eval_string(self, xctx: XPathContext) -> str:
         val = self._eval(xctx)
         if isinstance(val, float):
             try:
@@ -96,7 +95,7 @@ class Expr:
             return str(val).lower()
         return str(val)
 
-    def _xfunc_name(self: Expr) -> str:
+    def _xfunc_name(self) -> str:
         """Return XPath function name based on the class.
 
         To be used only for functions.
@@ -106,7 +105,7 @@ class Expr:
             [(c if c.islower() else f"-{c.lower()}") for
              c in fn[1:]])
 
-    def syntax_tree(self: Expr, indent: int = 0) -> str:
+    def syntax_tree(self, indent: int = 0) -> str:
         """Print abstract syntax tree of the receiver."""
         node_name = self.__class__.__name__
         attr = self._properties_str()
@@ -114,17 +113,17 @@ class Expr:
         return (" " * indent + node_name + attr_str +
                 self._children_ast(indent + self.indent))
 
-    def as_instance_route(self: Expr) -> InstanceRoute:
+    def as_instance_route(self) -> InstanceRoute:
         """Convert receiver to an InstanceRoute."""
         raise NotImplementedError
 
-    def _properties_str(self: Expr) -> str:
+    def _properties_str(self) -> str:
         return ""
 
-    def _children_ast(self: Expr, indent) -> str:
+    def _children_ast(self, indent) -> str:
         return ""
 
-    def _predicates_str(self: Expr, indent) -> str:
+    def _predicates_str(self, indent) -> str:
         if not self.predicates:
             return ""
         res = " " * indent + "-- Predicates:\n"
@@ -133,7 +132,7 @@ class Expr:
             res += p.syntax_tree(newi)
         return res
 
-    def _apply_predicates(self: Expr, ns: XPathValue,
+    def _apply_predicates(self, ns: XPathValue,
                           xctx: XPathContext) -> XPathValue:
         for p in self.predicates:
             res = NodeSet([])
@@ -155,47 +154,47 @@ class Expr:
 class UnaryExpr(Expr):
     """Abstract superclass for unary expressions."""
 
-    def __init__(self: UnaryExpr, expr: Optional[Expr]):
+    def __init__(self, expr: Optional[Expr]):
         self.expr = expr
 
-    def __str__(self: UnaryExpr) -> str:
+    def __str__(self) -> str:
         """Return string representation of a unary function.
 
         Non-function subclasses should override this method.
         """
         return f"{self._xfunc_name()}({self.expr if self.expr else ''})"
 
-    def _children_ast(self: UnaryExpr, indent: int) -> str:
+    def _children_ast(self, indent: int) -> str:
         return self.expr.syntax_tree(indent) if self.expr else ""
 
 
 class BinaryExpr(Expr):
     """Abstract superclass of binary expressions."""
 
-    def __init__(self: BinaryExpr, left: Expr, right: Expr):
+    def __init__(self, left: Expr, right: Expr):
         self.left = left
         self.right = right
 
-    def __str__(self: BinaryExpr) -> str:
+    def __str__(self) -> str:
         """Return string representation of a binary function.
 
         Non-function subclasses should override this method.
         """
         return f"{self._xfunc_name()}({self.left}, {self.right})"
 
-    def _children_ast(self: BinaryExpr, indent: int) -> str:
+    def _children_ast(self, indent: int) -> str:
         return self.left.syntax_tree(indent) + self.right.syntax_tree(indent)
 
-    def _eval_ops(self: BinaryExpr, xctx: XPathContext) -> Tuple[XPathValue, XPathValue]:
+    def _eval_ops(self, xctx: XPathContext) -> Tuple[XPathValue, XPathValue]:
         return (self.left._eval(xctx), self.right._eval(xctx))
 
-    def _eval_ops_float(self: BinaryExpr, xctx: XPathContext) -> Tuple[float, float]:
+    def _eval_ops_float(self, xctx: XPathContext) -> Tuple[float, float]:
         return (self.left._eval_float(xctx), self.right._eval_float(xctx))
 
-    def _eval_ops_string(self: BinaryExpr, xctx: XPathContext) -> Tuple[str, str]:
+    def _eval_ops_string(self, xctx: XPathContext) -> Tuple[str, str]:
         return (self.left._eval_string(xctx), self.right._eval_string(xctx))
 
-    def _as_str(self: BinaryExpr, op: str, spaces=True) -> str:
+    def _as_str(self, op: str, spaces=True) -> str:
         lft = str(self.left)
         if self.left._precedence < self._precedence:
             lft = "(" + lft + ")"
@@ -210,10 +209,10 @@ class OrExpr(BinaryExpr):
 
     _precedence = 0
 
-    def __str__(self: OrExpr) -> str:
+    def __str__(self) -> str:
         return self._as_str("or")
 
-    def _eval(self: OrExpr, xctx: XPathContext) -> bool:
+    def _eval(self, xctx: XPathContext) -> bool:
         lres, rres = self._eval_ops(xctx)
         return lres or rres
 
@@ -222,10 +221,10 @@ class AndExpr(BinaryExpr):
 
     _precedence = 1
 
-    def __str__(self: AndExpr) -> str:
+    def __str__(self) -> str:
         return self._as_str("and")
 
-    def _eval(self: AndExpr, xctx: XPathContext) -> bool:
+    def _eval(self, xctx: XPathContext) -> bool:
         lres, rres = self._eval_ops(xctx)
         return lres and rres
 
@@ -234,20 +233,20 @@ class EqualityExpr(BinaryExpr):
 
     _precedence = 2
 
-    def __init__(self: EqualityExpr, left: Expr, right: Expr, negate: bool):
+    def __init__(self, left: Expr, right: Expr, negate: bool):
         super().__init__(left, right)
         self.negate = negate
 
-    def __str__(self: EqualityExpr) -> str:
+    def __str__(self) -> str:
         return self._as_str("!=" if self.negate else "=")
 
-    def as_instance_route(self: EqualityExpr) -> InstanceRoute:
+    def as_instance_route(self) -> InstanceRoute:
         step = self.left
- 
-    def _properties_str(self: EqualityExpr) -> str:
+
+    def _properties_str(self) -> str:
         return "!=" if self.negate else "="
 
-    def _eval(self: EqualityExpr, xctx: XPathContext) -> bool:
+    def _eval(self, xctx: XPathContext) -> bool:
         lres, rres = self._eval_ops(xctx)
         return lres != rres if self.negate else lres == rres
 
@@ -256,23 +255,23 @@ class RelationalExpr(BinaryExpr):
 
     _precedence = 3
 
-    def __init__(self: RelationalExpr, left: Expr, right: Expr, less: bool,
+    def __init__(self, left: Expr, right: Expr, less: bool,
                  equal: bool):
         super().__init__(left, right)
         self.less = less
         self.equal = equal
 
-    def __str__(self: RelationalExpr) -> str:
+    def __str__(self) -> str:
         lg = "<" if self.less else ">"
         return self._as_str(lg + "=" if self.equal else lg)
 
-    def _properties_str(self: RelationalExpr) -> str:
+    def _properties_str(self) -> str:
         res = "<" if self.less else ">"
         if self.equal:
             res += "="
         return res
 
-    def _eval(self: RelationalExpr, xctx: XPathContext) -> bool:
+    def _eval(self, xctx: XPathContext) -> bool:
         lres, rres = self._eval_ops(xctx)
         if self.less:
             return lres <= rres if self.equal else lres < rres
@@ -283,17 +282,17 @@ class AdditiveExpr(BinaryExpr):
 
     _precedence = 4
 
-    def __init__(self: AdditiveExpr, left: Expr, right: Expr, plus: bool):
+    def __init__(self, left: Expr, right: Expr, plus: bool):
         super().__init__(left, right)
         self.plus = plus
 
-    def __str__(self: AdditiveExpr) -> str:
+    def __str__(self) -> str:
         return self._as_str("+" if self.plus else "-")
 
-    def _properties_str(self: AdditiveExpr) -> str:
+    def _properties_str(self) -> str:
         return "+" if self.plus else "-"
 
-    def _eval(self: AdditiveExpr, xctx: XPathContext) -> float:
+    def _eval(self, xctx: XPathContext) -> float:
         lres, rres = self._eval_ops_float(xctx)
         return lres + rres if self.plus else lres - rres
 
@@ -302,15 +301,15 @@ class MultiplicativeExpr(BinaryExpr):
 
     _precedence = 5
 
-    def __init__(self: MultiplicativeExpr, left: Expr, right: Expr,
+    def __init__(self, left: Expr, right: Expr,
                  operator: MultiplicativeOp):
         super().__init__(left, right)
         self.operator = operator
 
-    def __str__(self: MultiplicativeExpr) -> str:
+    def __str__(self) -> str:
         return self._as_str(str(self.operator))
 
-    def _properties_str(self: MultiplicativeExpr) -> str:
+    def _properties_str(self) -> str:
         if self.operator == MultiplicativeOp.multiply:
             return "*"
         if self.operator == MultiplicativeOp.divide:
@@ -318,7 +317,7 @@ class MultiplicativeExpr(BinaryExpr):
         if self.operator == MultiplicativeOp.modulo:
             return "mod"
 
-    def _eval(self: MultiplicativeExpr, xctx: XPathContext) -> float:
+    def _eval(self, xctx: XPathContext) -> float:
         lres, rres = self._eval_ops_float(xctx)
         if self.operator == MultiplicativeOp.multiply:
             return lres * rres
@@ -338,17 +337,17 @@ class UnaryMinusExpr(UnaryExpr):
 
     _precedence = 6
 
-    def __init__(self: UnaryMinusExpr, expr: Expr, negate: bool):
+    def __init__(self, expr: Expr, negate: bool):
         super().__init__(expr)
         self.negate = negate
 
-    def __str__(self: UnaryMinusExpr) -> str:
+    def __str__(self) -> str:
         return f"{'-' if self.negate else ''}{self.expr}"
 
-    def _properties_str(self: UnaryMinusExpr) -> str:
+    def _properties_str(self) -> str:
         return "-" if self.negate else "+"
 
-    def _eval(self: UnaryMinusExpr, xctx: XPathContext) -> float:
+    def _eval(self, xctx: XPathContext) -> float:
         res = self.expr._eval_float(xctx)
         return -res if self.negate else res
 
@@ -357,50 +356,50 @@ class UnionExpr(BinaryExpr):
 
     _precedence = 7
 
-    def __str__(self: UnionExpr) -> str:
+    def __str__(self) -> str:
         return self._as_str("|")
 
-    def _eval(self: UnionExpr, xctx: XPathContext) -> NodeSet:
+    def _eval(self, xctx: XPathContext) -> NodeSet:
         lres, rres = self._eval_ops(xctx)
         return lres.union(rres)
 
 
 class Literal(Expr):
 
-    def __init__(self: Literal, value: str):
+    def __init__(self, value: str):
         self.value = value
 
-    def __str__(self: Literal) -> str:
+    def __str__(self) -> str:
         return quoteattr(self.value)
 
-    def _properties_str(self: Literal) -> str:
+    def _properties_str(self) -> str:
         return self.value
 
-    def _eval(self: Literal, xctx: XPathContext) -> str:
+    def _eval(self, xctx: XPathContext) -> str:
         return self.value
 
 
 class Number(Expr):
 
-    def __init__(self: Number, value: float):
+    def __init__(self, value: float):
         self.value = value
 
-    def __str__(self: Number) -> str:
+    def __str__(self) -> str:
         return str(self.value)
 
-    def _properties_str(self: Number) -> str:
+    def _properties_str(self) -> str:
         return str(self.value)
 
-    def _eval(self: Number, xctx: XPathContext) -> float:
+    def _eval(self, xctx: XPathContext) -> float:
         return float(self.value)
 
 
 class PathExpr(BinaryExpr):
 
-    def __str__(self: PathExpr) -> str:
+    def __str__(self) -> str:
         return self._as_str("/", spaces=False)
 
-    def _eval(self: PathExpr, xctx: XPathContext) -> XPathValue:
+    def _eval(self, xctx: XPathContext) -> XPathValue:
         ns = self.left._eval(xctx)
         if not isinstance(ns, NodeSet):
             raise XPathTypeError(str(ns))
@@ -412,61 +411,61 @@ class PathExpr(BinaryExpr):
 
 class FilterExpr(Expr):
 
-    def __init__(self: FilterExpr, primary: Expr, predicates: List[Expr]):
+    def __init__(self, primary: Expr, predicates: List[Expr]):
         self.primary = primary
         self.predicates = predicates
 
-    def __str__(self: FilterExpr) -> str:
+    def __str__(self) -> str:
         return (str(self.primary) +
                 "".join([f"[{p}]" for p in self.predicates]))
 
-    def _children_ast(self: FilterExpr, indent) -> str:
+    def _children_ast(self, indent) -> str:
         return self.primary.syntax_tree(indent) + self._predicates_str(indent)
 
-    def _eval(self: FilterExpr, xctx: XPathContext) -> XPathValue:
+    def _eval(self, xctx: XPathContext) -> XPathValue:
         res = self.primary._eval(xctx)
         return self._apply_predicates(res, xctx)
 
 
 class LocationPath(BinaryExpr):
 
-    def _eval(self: LocationPath, xctx: XPathContext) -> XPathValue:
+    def _eval(self, xctx: XPathContext) -> XPathValue:
         lres = self.left._eval(xctx)
         ns = lres.bind(self.right._node_trans(xctx))
         return self.right._apply_predicates(ns, xctx)
 
-    def __str__(self: LocationPath) -> str:
+    def __str__(self) -> str:
         sep = "" if isinstance(self.left, Root) else "/"
         return f"{self.left}{sep}{self.right}"
 
-    def as_instance_route(self: LocationPath) -> InstanceRoute:
+    def as_instance_route(self) -> InstanceRoute:
         return InstanceRoute(self.left.as_instance_route() +
                              self.right.as_instance_route())
-   
+
 
 class Root(Expr):
 
     _precedence = 8
 
-    def _eval(self: Root, xctx: XPathContext) -> NodeSet:
+    def _eval(self, xctx: XPathContext) -> NodeSet:
         return NodeSet([xctx.cnode.top()])
 
-    def __str__(self: Root) -> str:
+    def __str__(self) -> str:
         return "/"
 
-    def as_instance_route(self: Root) -> InstanceRoute:
+    def as_instance_route(self) -> InstanceRoute:
         return InstanceRoute([])
 
 
 class Step(Expr):
 
-    def __init__(self: Step, axis: Axis, qname: QualName,
+    def __init__(self, axis: Axis, qname: QualName,
                  predicates: List[Expr]):
         self.axis = axis
         self.qname = qname
         self.predicates = predicates
 
-    def __str__(self: Step) -> str:
+    def __str__(self) -> str:
         if self.axis == Axis.descendant_or_self and self.qname is None:
             return ""
         if self.axis == Axis.self and self.qname is None:
@@ -483,7 +482,7 @@ class Step(Expr):
         prs = "".join([f"[{p}]" for p in self.predicates])
         return ax + qn + prs
 
-    def as_instance_route(self: Step) -> InstanceRoute:
+    def as_instance_route(self) -> InstanceRoute:
         m = MemberName(*self.qname)
         if not(self.predicates): return InstanceRoute([m])
         p0 = self.predicates[0]
@@ -494,15 +493,15 @@ class Step(Expr):
         else:                   # list keys
             ks = { p.left.qname: p.right.value for p in self.predicates }
             espec = EntryKeys(ks)
-        return InstanceRoute([m, espec]) 
-    
-    def _properties_str(self: Step) -> str:
+        return InstanceRoute([m, espec])
+
+    def _properties_str(self) -> str:
         return f"{self.axis.name} {self.qname}"
 
-    def _children_ast(self: Step, indent) -> str:
+    def _children_ast(self, indent) -> str:
         return self._predicates_str(indent)
 
-    def _node_trans(self: Step, xctx) -> NodeExpr:
+    def _node_trans(self, xctx) -> NodeExpr:
         return {
             Axis.ancestor: lambda n, qn=self.qname: n._ancestors(qn),
             Axis.ancestor_or_self:
@@ -523,14 +522,14 @@ class Step(Expr):
                 else [n],
         }[self.axis]
 
-    def _eval(self: Step, xctx: XPathContext) -> XPathValue:
+    def _eval(self, xctx: XPathContext) -> XPathValue:
         ns = NodeSet(self._node_trans(xctx)(xctx.cnode))
         return self._apply_predicates(ns, xctx)
 
 
 class FuncBitIsSet(BinaryExpr):
 
-    def _eval(self: FuncBitIsSet, xctx: XPathContext) -> bool:
+    def _eval(self, xctx: XPathContext) -> bool:
         ns = self.left._eval(xctx)
         if not isinstance(ns, NodeSet):
             raise XPathTypeError(str(ns))
@@ -543,57 +542,57 @@ class FuncBitIsSet(BinaryExpr):
 
 class FuncBoolean(UnaryExpr):
 
-    def _eval(self: FuncBoolean, xctx: XPathContext) -> bool:
+    def _eval(self, xctx: XPathContext) -> bool:
         return bool(self.expr._eval(xctx))
 
 
 class FuncCeiling(UnaryExpr):
 
-    def _eval(self: FuncCeiling, xctx: XPathContext) -> float:
+    def _eval(self, xctx: XPathContext) -> float:
         return float(ceil(self.expr._eval_float(xctx)))
 
 
 class FuncConcat(Expr):
 
-    def __init__(self: FuncConcat, parts: List[Expr]):
+    def __init__(self, parts: List[Expr]):
         self.parts = parts
 
-    def __str__(self: FuncConcat) -> str:
+    def __str__(self) -> str:
         return f"concat({', '.join([str(p) for p in self.parts])})"
 
-    def _children_ast(self: FuncConcat, indent: int) -> str:
+    def _children_ast(self, indent: int) -> str:
         return "".join([ex.syntax_tree(indent) for ex in self.parts])
 
-    def _eval(self: FuncConcat, xctx: XPathContext) -> str:
+    def _eval(self, xctx: XPathContext) -> str:
         return "".join([ex._eval_string(xctx) for ex in self.parts])
 
 
 class FuncContains(BinaryExpr):
 
-    def _eval(self: FuncContains, xctx: XPathContext) -> bool:
+    def _eval(self, xctx: XPathContext) -> bool:
         lres, rres = self._eval_ops_string(xctx)
         return lres.find(rres) >= 0
 
 
 class FuncCount(UnaryExpr):
 
-    def _eval(self: FuncCount, xctx: XPathContext) -> int:
+    def _eval(self, xctx: XPathContext) -> int:
         ns = self.expr._eval(xctx)
         return float(len(ns))
 
 
 class FuncCurrent(Expr):
 
-    def _eval(self: FuncCurrent, xctx: XPathContext) -> NodeSet:
+    def _eval(self, xctx: XPathContext) -> NodeSet:
         return NodeSet([xctx.origin])
 
-    def __str__(self: FuncCurrent) -> str:
+    def __str__(self) -> str:
         return "current()"
 
 
 class FuncDeref(UnaryExpr):
 
-    def _eval(self: FuncDeref, xctx: XPathContext) -> NodeSet:
+    def _eval(self, xctx: XPathContext) -> NodeSet:
         ns = self.expr._eval(xctx)
         if not isinstance(ns, NodeSet):
             raise XPathTypeError(str(ns))
@@ -603,20 +602,20 @@ class FuncDeref(UnaryExpr):
 
 class FuncDerivedFrom(BinaryExpr):
 
-    def __init__(self: FuncDerivedFrom, left: Expr, right: Expr, or_self: bool,
+    def __init__(self, left: Expr, right: Expr, or_self: bool,
                  sctx: SchemaContext):
         super().__init__(left, right)
         self.or_self = or_self
         self.sctx = sctx
 
-    def _xfunc_name(self: FuncDerivedFrom) -> str:
+    def _xfunc_name(self) -> str:
         return ("derived-from-or-self" if self.or_self else "derived-from")
 
-    def _properties_str(self: FuncDerivedFrom) -> str:
+    def _properties_str(self) -> str:
         return ("OR-SELF, " if self.or_self
                 else "") + self.sctx.schema_data.namespace(self.mid)
 
-    def _eval(self: FuncDerivedFrom, xctx: XPathContext) -> bool:
+    def _eval(self, xctx: XPathContext) -> bool:
         ns = self.left._eval(xctx)
         if not isinstance(ns, NodeSet):
             raise XPathTypeError(str(ns))
@@ -634,7 +633,7 @@ class FuncDerivedFrom(BinaryExpr):
 
 class FuncEnumValue(UnaryExpr):
 
-    def _eval(self: FuncEnumValue, xctx: XPathContext) -> float:
+    def _eval(self, xctx: XPathContext) -> float:
         ns = self.expr._eval(xctx)
         if not isinstance(ns, NodeSet):
             raise XPathTypeError(str(ns))
@@ -647,42 +646,42 @@ class FuncEnumValue(UnaryExpr):
 
 class FuncFalse(Expr):
 
-    def __str__(self: FuncFalse) -> str:
+    def __str__(self) -> str:
         return "false()"
 
-    def _eval(self: FuncFalse, xctx: XPathContext) -> bool:
+    def _eval(self, xctx: XPathContext) -> bool:
         return False
 
 
 class FuncFloor(UnaryExpr):
 
-    def _eval(self: FuncFloor, xctx: XPathContext) -> float:
+    def _eval(self, xctx: XPathContext) -> float:
         return float(floor(self.expr._eval_float(xctx)))
 
 
 class FuncLast(Expr):
 
-    def __str__(self: FuncLast) -> str:
+    def __str__(self) -> str:
         return "last()"
 
-    def _eval(self: FuncLast, xctx: XPathContext) -> int:
+    def _eval(self, xctx: XPathContext) -> int:
         return float(xctx.size)
 
 
 class FuncName(UnaryExpr):
 
-    def __init__(self: FuncName, expr: Optional[Expr], local: bool):
+    def __init__(self, expr: Optional[Expr], local: bool):
         super().__init__(expr)
         self.local = local
 
-    def __str__(self: FuncName) -> str:
+    def __str__(self) -> str:
         fn = "local-name" if self.local else "name"
         return f"{fn}({self.expr if self.expr else ''})"
 
-    def _properties_str(self: FuncName) -> str:
+    def _properties_str(self) -> str:
         return "LOCAL" if self.local else ""
 
-    def _eval(self: FuncName, xctx: XPathContext) -> str:
+    def _eval(self, xctx: XPathContext) -> str:
         if self.expr is None:
             node = xctx.cnode
         else:
@@ -703,20 +702,20 @@ class FuncName(UnaryExpr):
 
 class FuncNormalizeSpace(UnaryExpr):
 
-    def _eval(self: FuncNormalizeSpace, xctx: XPathContext) -> str:
+    def _eval(self, xctx: XPathContext) -> str:
         string = self.expr._eval_string(xctx) if self.expr else str(xctx.cnode)
         return " ".join(string.strip().split())
 
 
 class FuncNot(UnaryExpr):
 
-    def _eval(self: FuncNot, xctx: XPathContext) -> bool:
+    def _eval(self, xctx: XPathContext) -> bool:
         return not(self.expr._eval(xctx))
 
 
 class FuncNumber(UnaryExpr):
 
-    def _eval(self: FuncNumber, xctx: XPathContext) -> float:
+    def _eval(self, xctx: XPathContext) -> float:
         if self.expr is None:
             try:
                 return float(xctx.cnode.value)
@@ -727,16 +726,16 @@ class FuncNumber(UnaryExpr):
 
 class FuncPosition(Expr):
 
-    def __str__(self: FuncPosition) -> str:
+    def __str__(self) -> str:
         return "position()"
 
-    def _eval(self: FuncPosition, xctx: XPathContext) -> int:
+    def _eval(self, xctx: XPathContext) -> int:
         return xctx.position
 
 
 class FuncReMatch(BinaryExpr):
 
-    def _eval(self: FuncReMatch, xctx: XPathContext) -> bool:
+    def _eval(self, xctx: XPathContext) -> bool:
         lres, rres = self._eval_ops_string(xctx)
         try:
             return re.match(XMLToPython(rres), lres) is not None
@@ -746,7 +745,7 @@ class FuncReMatch(BinaryExpr):
 
 class FuncRound(UnaryExpr):
 
-    def _eval(self: FuncRound, xctx: XPathContext) -> float:
+    def _eval(self, xctx: XPathContext) -> float:
         dec = decimal.Decimal(self.expr._eval_float(xctx))
         try:
             return float(dec.to_integral_value(
@@ -757,14 +756,14 @@ class FuncRound(UnaryExpr):
 
 class FuncStartsWith(BinaryExpr):
 
-    def _eval(self: FuncStartsWith, xctx: XPathContext) -> bool:
+    def _eval(self, xctx: XPathContext) -> bool:
         lres, rres = self._eval_ops_string(xctx)
         return lres.startswith(rres)
 
 
 class FuncString(UnaryExpr):
 
-    def _eval(self: FuncString, xctx: XPathContext) -> str:
+    def _eval(self, xctx: XPathContext) -> str:
         if self.expr is None:
             return str(xctx.cnode)
         return self.expr._eval_string(xctx)
@@ -772,28 +771,28 @@ class FuncString(UnaryExpr):
 
 class FuncStringLength(UnaryExpr):
 
-    def _eval(self: FuncStringLength, xctx: XPathContext) -> str:
+    def _eval(self, xctx: XPathContext) -> str:
         string = self.expr._eval_string(xctx) if self.expr else str(xctx.cnode)
         return float(len(string))
 
 
 class FuncSubstring(BinaryExpr):
 
-    def __init__(self: FuncSubstring, string: Expr, start: Expr,
+    def __init__(self, string: Expr, start: Expr,
                  length: Optional[Expr]):
         super().__init__(string, start)
         self.length = length
 
-    def __str__(self: FuncSubstring) -> str:
+    def __str__(self) -> str:
         res = f"{self._xfunc_name()}({self.left}, {self.right}"
         if self.length:
             res += f", {self.length}"
         return res + ")"
 
-    def _children_ast(self: FuncSubstring, indent: int) -> str:
+    def _children_ast(self, indent: int) -> str:
         return super()._children_ast(indent) + self.length.syntax_tree(indent)
 
-    def _eval(self: FuncSubstring, xctx: XPathContext) -> str:
+    def _eval(self, xctx: XPathContext) -> str:
         string = self.left._eval_string(xctx)
         rres = self.right._eval_float(xctx)
         try:
@@ -812,7 +811,7 @@ class FuncSubstring(BinaryExpr):
 
 class FuncSubstringAfter(BinaryExpr):
 
-    def _eval(self: FuncSubstringAfter, xctx: XPathContext) -> str:
+    def _eval(self, xctx: XPathContext) -> str:
         lres, rres = self._eval_ops_string(xctx)
         ind = lres.find(rres)
         return lres[ind + len(rres):] if ind >= 0 else ""
@@ -820,7 +819,7 @@ class FuncSubstringAfter(BinaryExpr):
 
 class FuncSubstringBefore(BinaryExpr):
 
-    def _eval(self: FuncSubstringBefore, xctx: XPathContext) -> str:
+    def _eval(self, xctx: XPathContext) -> str:
         lres, rres = self._eval_ops_string(xctx)
         ind = lres.find(rres)
         return lres[:ind] if ind >= 0 else ""
@@ -828,7 +827,7 @@ class FuncSubstringBefore(BinaryExpr):
 
 class FuncSum(UnaryExpr):
 
-    def _eval(self: FuncSum, xctx: XPathContext) -> float:
+    def _eval(self, xctx: XPathContext) -> float:
         ns = self.expr._eval(xctx)
         if not isinstance(ns, NodeSet):
             raise XPathTypeError(str(ns))
@@ -840,17 +839,17 @@ class FuncSum(UnaryExpr):
 
 class FuncTranslate(BinaryExpr):
 
-    def __init__(self: FuncTranslate, s1: Expr, s2: Expr, s3: Expr):
+    def __init__(self, s1: Expr, s2: Expr, s3: Expr):
         super().__init__(s1, s2)
         self.nchars = s3
 
-    def __str__(self: FuncTranslate) -> str:
+    def __str__(self) -> str:
         return f"{self._xfunc_name()}({self.left}, {self.right}, {self.nchars})"
 
-    def _children_ast(self: FuncTranslate, indent: int) -> str:
+    def _children_ast(self, indent: int) -> str:
         return super()._children_ast(indent) + self.nchars.syntax_tree(indent)
 
-    def _eval(self: FuncTranslate, xctx: XPathContext) -> str:
+    def _eval(self, xctx: XPathContext) -> str:
         string, old = self._eval_ops_string(xctx)
         new = self.nchars._eval_string(xctx)[:len(old)]
         ttab = str.maketrans(old[:len(new)], new, old[len(new):])
@@ -859,8 +858,8 @@ class FuncTranslate(BinaryExpr):
 
 class FuncTrue(Expr):
 
-    def __str__(self: FuncTrue) -> str:
+    def __str__(self) -> str:
         return "true()"
 
-    def _eval(self: FuncTrue, xctx: XPathContext) -> bool:
+    def _eval(self, xctx: XPathContext) -> bool:
         return True

--- a/yangson/xpathparser.py
+++ b/yangson/xpathparser.py
@@ -25,7 +25,6 @@ The module also defines the following exceptions:
 
 """
 
-from __future__ import annotations
 from typing import List, Optional, Tuple, Union
 from .schemadata import SchemaContext
 from .enumerations import Axis, MultiplicativeOp
@@ -46,7 +45,7 @@ from .xpathast import (
 class XPathParser(Parser):
     """Parser for XPath expressions."""
 
-    def __init__(self: XPathParser, text: str, sctx: SchemaContext):
+    def __init__(self, text: str, sctx: SchemaContext):
         """Initialize the parser instance.
 
         Args:
@@ -55,7 +54,7 @@ class XPathParser(Parser):
         super().__init__(text)
         self.sctx = sctx
 
-    def parse(self: XPathParser) -> Expr:
+    def parse(self) -> Expr:
         """Parse an XPath expression.
 
         Returns:
@@ -69,7 +68,7 @@ class XPathParser(Parser):
         self.skip_ws()
         return self._or_expr()
 
-    def _or_expr(self: XPathParser) -> Expr:
+    def _or_expr(self) -> Expr:
         op1 = self._and_expr()
         while self.test_string("or"):
             self.skip_ws()
@@ -77,7 +76,7 @@ class XPathParser(Parser):
             op1 = OrExpr(op1, op2)
         return op1
 
-    def _and_expr(self: XPathParser) -> Expr:
+    def _and_expr(self) -> Expr:
         op1 = self._equality_expr()
         while self.test_string("and"):
             self.skip_ws()
@@ -85,7 +84,7 @@ class XPathParser(Parser):
             op1 = AndExpr(op1, op2)
         return op1
 
-    def _equality_expr(self: XPathParser) -> Expr:
+    def _equality_expr(self) -> Expr:
         op1 = self._relational_expr()
         while True:
             negate = False
@@ -108,7 +107,7 @@ class XPathParser(Parser):
             op2 = self._relational_expr()
             op1 = EqualityExpr(op1, op2, negate)
 
-    def _relational_expr(self: XPathParser) -> Expr:
+    def _relational_expr(self) -> Expr:
         op1 = self._additive_expr()
         while True:
             try:
@@ -123,7 +122,7 @@ class XPathParser(Parser):
             op2 = self._additive_expr()
             op1 = RelationalExpr(op1, op2, rel == "<", eq)
 
-    def _additive_expr(self: XPathParser) -> Expr:
+    def _additive_expr(self) -> Expr:
         op1 = self._multiplicative_expr()
         while True:
             try:
@@ -136,7 +135,7 @@ class XPathParser(Parser):
             op2 = self._multiplicative_expr()
             op1 = AdditiveExpr(op1, op2, pm == "+")
 
-    def _multiplicative_expr(self: XPathParser) -> Expr:
+    def _multiplicative_expr(self) -> Expr:
         op1 = self._unary_minus_expr()
         while True:
             if self.test_string("*"):
@@ -151,7 +150,7 @@ class XPathParser(Parser):
             op2 = self._unary_minus_expr()
             op1 = MultiplicativeExpr(op1, op2, mulop)
 
-    def _unary_minus_expr(self: XPathParser) -> Expr:
+    def _unary_minus_expr(self) -> Expr:
         negate = None
         while self.test_string("-"):
             negate = not negate
@@ -159,7 +158,7 @@ class XPathParser(Parser):
         expr = self._union_expr()
         return expr if negate is None else UnaryMinusExpr(expr, negate)
 
-    def _union_expr(self: XPathParser) -> Expr:
+    def _union_expr(self) -> Expr:
         op1 = self._lit_num_path()
         while self.test_string("|"):
             self.skip_ws()
@@ -167,7 +166,7 @@ class XPathParser(Parser):
             op1 = UnionExpr(op1, op2)
         return op1
 
-    def _lit_num_path(self: XPathParser) -> Expr:
+    def _lit_num_path(self) -> Expr:
         next = self.peek()
         if next == "(":
             self.adv_skip_ws()
@@ -196,13 +195,13 @@ class XPathParser(Parser):
         self.offset = start
         return self._location_path()
 
-    def _path_expr(self: XPathParser, fname: str) -> Expr:
+    def _path_expr(self, fname: str) -> Expr:
         fexpr = self._filter_expr(fname)
         if self.test_string("/"):
             return PathExpr(fexpr, self._location_path())
         return fexpr
 
-    def _filter_expr(self: XPathParser, fname: str) -> Expr:
+    def _filter_expr(self, fname: str) -> Expr:
         if fname is None:
             prim = self._or_expr()
         else:
@@ -217,7 +216,7 @@ class XPathParser(Parser):
         self.skip_ws()
         return FilterExpr(prim, self._predicates())
 
-    def _predicates(self: XPathParser) -> List[Expr]:
+    def _predicates(self) -> List[Expr]:
         res = []
         while self.test_string("["):
             self.skip_ws()
@@ -226,10 +225,10 @@ class XPathParser(Parser):
             self.skip_ws()
         return res
 
-    def _predicate(self: XPathParser) -> Expr:
+    def _predicate(self) -> Expr:
         return self._or_expr()
 
-    def _location_path(self: XPathParser) -> LocationPath:
+    def _location_path(self) -> LocationPath:
         if self.test_string("/"):
             self.skip_ws()
             if self.at_end():
@@ -243,10 +242,10 @@ class XPathParser(Parser):
             op1 = LocationPath(op1, op2)
         return op1
 
-    def _step(self: XPathParser) -> Step:
+    def _step(self) -> Step:
         return Step(*self._axis_qname(), self._predicates())
 
-    def _axis_qname(self: XPathParser) -> Tuple[Axis, Union[QualName, bool, None]]:
+    def _axis_qname(self) -> Tuple[Axis, Union[QualName, bool, None]]:
         next = self.peek()
         if next == "*":
             self.adv_skip_ws()
@@ -291,7 +290,7 @@ class XPathParser(Parser):
             return Axis.child, (loc, nsp)
         return Axis.child, (yid, self.sctx.default_ns)
 
-    def _node_type(self: XPathParser, typ):
+    def _node_type(self, typ):
         if typ == "node":
             self.adv_skip_ws()
             self.char(")")
@@ -301,7 +300,7 @@ class XPathParser(Parser):
             raise NotSupported(self, f"node type '{typ}()'")
         raise InvalidXPath(self)
 
-    def _qname(self: XPathParser) -> Optional[QualName]:
+    def _qname(self) -> Optional[QualName]:
         """Parse XML QName."""
         if self.test_string("*"):
             self.skip_ws()
@@ -323,25 +322,25 @@ class XPathParser(Parser):
         self.skip_ws()
         return res
 
-    def _opt_arg(self: XPathParser) -> Optional[Expr]:
+    def _opt_arg(self) -> Optional[Expr]:
         return None if self.peek() == ")" else self.parse()
 
-    def _two_args(self: XPathParser) -> Tuple[Expr, Expr]:
+    def _two_args(self) -> Tuple[Expr, Expr]:
         fst = self.parse()
         self.char(",")
         self.skip_ws()
         return fst, self.parse()
 
-    def _func_bit_is_set(self: XPathParser) -> FuncBitIsSet:
+    def _func_bit_is_set(self) -> FuncBitIsSet:
         return FuncBitIsSet(*self._two_args())
 
-    def _func_boolean(self: XPathParser) -> FuncBoolean:
+    def _func_boolean(self) -> FuncBoolean:
         return FuncBoolean(self.parse())
 
-    def _func_ceiling(self: XPathParser) -> FuncCeiling:
+    def _func_ceiling(self) -> FuncCeiling:
         return FuncCeiling(self.parse())
 
-    def _func_concat(self: XPathParser) -> FuncConcat:
+    def _func_concat(self) -> FuncConcat:
         res = [self.parse()]
         while self.test_string(","):
             self.skip_ws()
@@ -350,70 +349,70 @@ class XPathParser(Parser):
             raise InvalidXPath(self)
         return FuncConcat(res)
 
-    def _func_contains(self: XPathParser) -> FuncContains:
+    def _func_contains(self) -> FuncContains:
         return FuncContains(*self._two_args())
 
-    def _func_count(self: XPathParser) -> FuncCount:
+    def _func_count(self) -> FuncCount:
         return FuncCount(self.parse())
 
-    def _func_current(self: XPathParser) -> FuncCurrent:
+    def _func_current(self) -> FuncCurrent:
         return FuncCurrent()
 
-    def _func_deref(self: XPathParser) -> FuncDeref:
+    def _func_deref(self) -> FuncDeref:
         return FuncDeref(self.parse())
 
-    def _func_derived_from(self: XPathParser) -> FuncDerivedFrom:
+    def _func_derived_from(self) -> FuncDerivedFrom:
         return FuncDerivedFrom(*self._two_args(), False, self.sctx)
 
-    def _func_derived_from_or_self(self: XPathParser) -> FuncDerivedFrom:
+    def _func_derived_from_or_self(self) -> FuncDerivedFrom:
         return FuncDerivedFrom(*self._two_args(), True, self.sctx)
 
-    def _func_enum_value(self: XPathParser) -> FuncEnumValue:
+    def _func_enum_value(self) -> FuncEnumValue:
         return FuncEnumValue(self.parse())
 
-    def _func_false(self: XPathParser) -> FuncFalse:
+    def _func_false(self) -> FuncFalse:
         return FuncFalse()
 
-    def _func_floor(self: XPathParser) -> FuncFloor:
+    def _func_floor(self) -> FuncFloor:
         return FuncFloor(self.parse())
 
-    def _func_last(self: XPathParser) -> FuncLast:
+    def _func_last(self) -> FuncLast:
         return FuncLast()
 
-    def _func_local_name(self: XPathParser) -> FuncName:
+    def _func_local_name(self) -> FuncName:
         return FuncName(self._opt_arg(), local=True)
 
-    def _func_name(self: XPathParser) -> FuncName:
+    def _func_name(self) -> FuncName:
         return FuncName(self._opt_arg(), local=False)
 
-    def _func_normalize_space(self: XPathParser) -> FuncNormalizeSpace:
+    def _func_normalize_space(self) -> FuncNormalizeSpace:
         return FuncNormalizeSpace(self._opt_arg())
 
-    def _func_not(self: XPathParser) -> FuncNot:
+    def _func_not(self) -> FuncNot:
         return FuncNot(self.parse())
 
-    def _func_number(self: XPathParser) -> FuncNumber:
+    def _func_number(self) -> FuncNumber:
         return FuncNumber(self._opt_arg())
 
-    def _func_position(self: XPathParser) -> FuncPosition:
+    def _func_position(self) -> FuncPosition:
         return FuncPosition()
 
-    def _func_re_match(self: XPathParser) -> FuncReMatch:
+    def _func_re_match(self) -> FuncReMatch:
         return FuncReMatch(*self._two_args())
 
-    def _func_round(self: XPathParser) -> FuncRound:
+    def _func_round(self) -> FuncRound:
         return FuncRound(self.parse())
 
-    def _func_starts_with(self: XPathParser) -> FuncStartsWith:
+    def _func_starts_with(self) -> FuncStartsWith:
         return FuncStartsWith(*self._two_args())
 
-    def _func_string(self: XPathParser) -> FuncString:
+    def _func_string(self) -> FuncString:
         return FuncString(self._opt_arg())
 
-    def _func_string_length(self: XPathParser) -> FuncStringLength:
+    def _func_string_length(self) -> FuncStringLength:
         return FuncStringLength(self._opt_arg())
 
-    def _func_substring(self: XPathParser) -> FuncSubstring:
+    def _func_substring(self) -> FuncSubstring:
         string, start = self._two_args()
         if self.test_string(","):
             self.skip_ws()
@@ -422,20 +421,20 @@ class XPathParser(Parser):
             length = None
         return FuncSubstring(string, start, length)
 
-    def _func_substring_after(self: XPathParser) -> FuncSubstringAfter:
+    def _func_substring_after(self) -> FuncSubstringAfter:
         return FuncSubstringAfter(*self._two_args())
 
-    def _func_substring_before(self: XPathParser) -> FuncSubstringBefore:
+    def _func_substring_before(self) -> FuncSubstringBefore:
         return FuncSubstringBefore(*self._two_args())
 
-    def _func_sum(self: XPathParser) -> FuncSum:
+    def _func_sum(self) -> FuncSum:
         return FuncSum(self.parse())
 
-    def _func_translate(self: XPathParser) -> FuncTranslate:
+    def _func_translate(self) -> FuncTranslate:
         s1, s2 = self._two_args()
         self.char(",")
         self.skip_ws()
         return FuncTranslate(s1, s2, self.parse())
 
-    def _func_true(self: XPathParser) -> FuncTrue:
+    def _func_true(self) -> FuncTrue:
         return FuncTrue()


### PR DESCRIPTION
Removes use of `from __future__ import annotations`.

Fixes #82: I figured as well as asking you the question about whether you'd accept this MR, it was no great trouble actually to do it.  