### PR TITLE
Fix python 3.6 support

### DIFF
--- a/yangson/constraint.py
+++ b/yangson/constraint.py
@@ -24,8 +24,6 @@ This module implements the following classes:
 * Pattern: Class representing regular expression pattern.
 * Must: Class representing the constraint specified by a "must" statement.
 """
-from __future__ import annotations
-
 import decimal
 import re
 from typing import Callable, List, Optional, Union

--- a/yangson/datamodel.py
+++ b/yangson/datamodel.py
@@ -21,8 +21,6 @@ This module implements the following class:
 
 * DataModel: Basic entry point to the YANG data model.
 """
-from __future__ import annotations
-
 import hashlib
 import json
 from typing import Optional, Tuple

--- a/yangson/datatype.py
+++ b/yangson/datatype.py
@@ -43,8 +43,6 @@ This module implements the following classes:
 * Uint64Type: YANG uint64 type.
 * UnionType: YANG union type.
 """
-from __future__ import annotations
-
 import base64
 import decimal
 import numbers
@@ -403,7 +401,7 @@ class BooleanType(DataType):
         if val is False:
             return "false"
 
-    def to_xml(self: BooleanType, val: bool) -> str:
+    def to_xml(self: "BooleanType", val: bool) -> str:
         return self.canonical_string(val)
 
 

--- a/yangson/enumerations.py
+++ b/yangson/enumerations.py
@@ -16,8 +16,6 @@
 # with Yangson.  If not, see <http://www.gnu.org/licenses/>.
 
 """Enumeration classes."""
-from __future__ import annotations
-
 from enum import Enum
 
 

--- a/yangson/exceptions.py
+++ b/yangson/exceptions.py
@@ -68,8 +68,6 @@ This module defines the following exceptions:
 * :exc:`YangsonException`: Base class for all Yangson exceptions.
 * :exc:`YangTypeError`: A scalar value is of incorrect type.
 """
-from __future__ import annotations
-
 from typing import TYPE_CHECKING
 from .typealiases import (InstanceName, JSONPointer, ModuleId, PrefName,
                           QualName, ScalarValue, YangIdentifier)

--- a/yangson/instance.py
+++ b/yangson/instance.py
@@ -28,8 +28,6 @@ This module implements the following classes:
 * ResourceIdParser: Parser for RESTCONF resource identifiers.
 * InstanceIdParser: Parser for instance identifiers.
 """
-from __future__ import annotations
-
 from datetime import datetime
 import json
 from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING, Union

--- a/yangson/instvalue.py
+++ b/yangson/instvalue.py
@@ -23,8 +23,6 @@ This module implements the following classes:
 * ArrayValue: Cooked array value of an instance node.
 * ObjectValue: Cooked object value of an instance node.
 """
-from __future__ import annotations
-
 from datetime import datetime
 from typing import Dict, List, Union
 from .typealiases import InstanceName, PrefName, ScalarValue

--- a/yangson/nodeset.py
+++ b/yangson/nodeset.py
@@ -16,8 +16,6 @@
 # with Yangson.  If not, see <http://www.gnu.org/licenses/>.
 
 """XPath node-set"""
-from __future__ import annotations
-
 from typing import Callable, Union
 from numbers import Number
 from .instance import InstanceNode

--- a/yangson/parser.py
+++ b/yangson/parser.py
@@ -21,8 +21,6 @@ This module implements the following class:
 
 * Parser: Recursive-descent parser.
 """
-from __future__ import annotations
-
 import re
 from typing import Callable, List, Dict, Optional, Tuple
 from typing.re import Pattern

--- a/yangson/schemadata.py
+++ b/yangson/schemadata.py
@@ -25,8 +25,6 @@ This module implements the following classes:
 * SchemaData: Repository of YANG schema structures and methods.
 * FeatureExprParser: Parser for if-feature expressions.
 """
-from __future__ import annotations
-
 from typing import Any, Dict, List, MutableSet, Tuple
 from .exceptions import (
     InvalidSchemaPath, BadYangLibraryData, CyclicImports, DefinitionNotFound,

--- a/yangson/schemanode.py
+++ b/yangson/schemanode.py
@@ -40,8 +40,6 @@ This module implements the following classes:
 * AnydataNode: YANG anydata node.
 * AnyxmlNode: YANG anyxml node.
 """
-from __future__ import annotations
-
 from datetime import datetime
 from itertools import product
 from typing import Any, Dict, List, MutableSet, Optional, Set, Tuple

--- a/yangson/schpattern.py
+++ b/yangson/schpattern.py
@@ -16,8 +16,6 @@
 # with Yangson.  If not, see <http://www.gnu.org/licenses/>.
 
 """This module defines classes for schema patterns."""
-from __future__ import annotations
-
 from typing import List, Optional, TYPE_CHECKING
 from .enumerations import ContentType
 from .typealiases import InstanceName, _Singleton, YangIdentifier

--- a/yangson/statement.py
+++ b/yangson/statement.py
@@ -22,8 +22,6 @@ This module implements the following classes:
 * ModuleParser: Recursive-descent parser for YANG modules.
 * Statement: YANG statements.
 """
-from __future__ import annotations
-
 from typing import List, Optional, Tuple
 from .exceptions import (
     EndOfInput, StatementNotFound, UnexpectedInput, InvalidArgument,

--- a/yangson/xpathast.py
+++ b/yangson/xpathast.py
@@ -23,8 +23,6 @@ class is intended to be public:
 
 * Expr: XPath 1.0 expression with YANG 1.1 extensions.
 """
-from __future__ import annotations
-
 import decimal
 from math import ceil, copysign, floor
 from pyxb.utils.xmlre import XMLToPython, RegularExpressionError

--- a/yangson/xpathparser.py
+++ b/yangson/xpathparser.py
@@ -24,8 +24,6 @@ This module defines the following classes:
 The module also defines the following exceptions:
 
 """
-from __future__ import annotations
-
 from typing import List, Optional, Tuple, Union
 from .schemadata import SchemaContext
 from .enumerations import Axis, MultiplicativeOp


### PR DESCRIPTION
#81 undid some of the work from #85, once again breaking python 3.6 compatibility.  A mismerge, I expect.

@kwatsen FYI.

This MR fixes it again.