### PR TITLE
Xml improved 2

### DIFF
--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -736,7 +736,7 @@ def test_xml_config(xml_safe_data_model, xml_safe_data):
     # convert InstanceValue to an XML-encoded string
     xml_obj = inst.to_xml()
     xml_text = ET.tostring(xml_obj).decode("utf-8")
-    #assert(xml_text == expected_xml_stripped) # fails, see Issue #87
+    assert(xml_text == expected_xml_stripped)
 
     # convert XML-encoded string back to an InstanceValue
     parser = XMLParser(expected_xml_stripped)
@@ -751,7 +751,6 @@ def test_xml_config(xml_safe_data_model, xml_safe_data):
     # ensure raw value is same
     rv = inst2.raw_value()
     assert(rv == xml_safe_data)
-
 
 
 
@@ -800,7 +799,7 @@ def test_xml_rpc(data_model):
 
     # convert raw object to an InstanceValue
     #  - an ObjectValue, not a RootNode as per DataModel.from_raw()
-    input_inst_val = sn_rpc.from_raw(input_obj, allow_nodata=True)
+    input_inst_val = sn_rpc.from_raw(input_obj)
     assert(str(input_inst_val) == str(input_obj))
 
     # convert InstanceValue to an Instance (a RootNode)
@@ -817,7 +816,7 @@ def test_xml_rpc(data_model):
     #  - an ObjectValue, not a RootNode as per DataModel.from_xml()
     parser = XMLParser(input_xml_text)
     input_xml_et_obj2 = parser.root
-    input_inst_val2 = sn_rpc.from_xml(input_xml_et_obj2, isroot=True, allow_nodata=True)
+    input_inst_val2 = sn_rpc.from_xml(input_xml_et_obj2)
     assert(input_inst_val2 == input_inst_val)
 
     # convert InstanceValue back to an Instance (a RootNode)
@@ -837,7 +836,7 @@ def test_xml_rpc(data_model):
 
     # convert raw object to an InstanceValue
     #  - an ObjectValue, not a RootNode as per DataModel.from_raw()
-    output_inst_val = sn_rpc.from_raw(output_obj, allow_nodata=True)
+    output_inst_val = sn_rpc.from_raw(output_obj)
     assert(str(output_inst_val) == str(output_obj))
 
     # convert InstanceValue to an Instance (a RootNode)
@@ -854,7 +853,7 @@ def test_xml_rpc(data_model):
     #  - an ObjectValue, not a RootNode as per DataModel.from_xml()
     parser = XMLParser(output_xml_text)
     output_xml_et_obj2 = parser.root
-    output_inst_val2 = sn_rpc.from_xml(output_xml_et_obj2, isroot=True, allow_nodata=True)
+    output_inst_val2 = sn_rpc.from_xml(output_xml_et_obj2)
     assert(output_inst_val2 == output_inst_val)
 
     # convert InstanceValue back to an Instance (a RootNode)
@@ -865,7 +864,6 @@ def test_xml_rpc(data_model):
     # convert Instance to raw value and ensure same
     output_rv2 = output_inst2.raw_value()
     assert(output_rv2 == output_obj)
-
 
 
 def test_xml_action(data_model):
@@ -887,7 +885,7 @@ def test_xml_action(data_model):
 
     output_xml_stripped = strip_pretty(output_xml_pretty)
 
-    # get the schema node for the 'action' 
+    # get the schema node for the 'action'
     sn_action = data_model.get_schema_node("/test:contA/listA/contD/acA")
     assert(type(sn_action) == RpcActionNode)
 
@@ -903,7 +901,7 @@ def test_xml_action(data_model):
 
     # convert raw object to an InstanceValue
     #  - an ObjectValue, not a RootNode as per DataModel.from_raw()
-    output_inst_val = sn_action.from_raw(output_obj, allow_nodata=True)
+    output_inst_val = sn_action.from_raw(output_obj)
     assert(str(output_inst_val) == str(output_obj))
 
     # convert InstanceValue to an Instance (a RootNode)
@@ -920,7 +918,7 @@ def test_xml_action(data_model):
     #  - an ObjectValue, not a RootNode as per DataModel.from_xml()
     parser = XMLParser(output_xml_text)
     output_xml_et_obj2 = parser.root
-    output_inst_val2 = sn_action.from_xml(output_xml_et_obj2, isroot=True, allow_nodata=True)
+    output_inst_val2 = sn_action.from_xml(output_xml_et_obj2)
     assert(output_inst_val2 == output_inst_val)
 
     # convert InstanceValue back to an Instance (a RootNode)
@@ -946,76 +944,28 @@ def test_xml_notification(data_model):
     sn_notif = data_model.get_schema_node("/testb:noA")
     assert(type(sn_notif) == NotificationNode)
 
-    #######
-    # NOA #
-    #######
+    #########
+    # NOTIF #  (most common?)
+    #########
 
-    noA_obj = {
-        "testb:leafO" : True
+    notif_obj = {
+        "testb:noA" : {
+            "leafO" : True
+        }
     }
-    noA_xml_pretty = """
-        <leafO xmlns="http://example.com/testb">true</leafO>
+    notif_xml_pretty = """
+        <noa xmlns="http://example.com/testb">
+            <leafO>true</leafO>
+        </noa>
     """
-    noA_xml_stripped = strip_pretty(noA_xml_pretty)
-
-    # convert raw object to an InstanceValue
-    #  - an ObjectValue, not a RootNode as per DataModel.from_raw()
-    noA_inst_val = sn_notif.from_raw(noA_obj, allow_nodata=True)
-    assert(str(noA_inst_val) == str(noA_obj))
-
-    # convert InstanceValue to an Instance (a RootNode)
-    noA_inst = RootNode(noA_inst_val, sn_notif, data_model.schema_data, noA_inst_val.timestamp)
-    noA_inst.validate(ctype=ContentType.all)
-    assert(noA_inst.raw_value() == noA_obj)
-
-    # convert Instance to an XML-encoded string and compare to known-good
-    noA_xml_et_obj = noA_inst.to_xml()
-    noA_xml_text = ET.tostring(noA_xml_et_obj).decode("utf-8")
-    assert(noA_xml_text == noA_xml_stripped)
-
-    # convert noa's XML-encoded string back to an InstanceValue
-    #  - an ObjectValue, not a RootNode as per DataModel.from_xml()
-    parser = XMLParser(noA_xml_text)
-    noA_xml_et_obj2 = parser.root
-    noA_inst_val2 = sn_notif.from_xml(noA_xml_et_obj2, isroot=True, allow_nodata=True)
-    assert(noA_inst_val2 == noA_inst_val)
-
-    # convert InstanceValue back to an Instance (a RootNode)
-    noA_inst2 = RootNode(noA_inst_val2, sn_notif, data_model.schema_data, noA_inst_val2.timestamp)
-    noA_inst2.validate(ctype=ContentType.all)
-    assert(noA_inst2.raw_value() == noA_obj)
-
-    # convert Instance to raw value and ensure same
-    noA_rv2 = noA_inst2.raw_value()
-    assert(noA_rv2 == noA_obj)
+    notif_xml_stripped = strip_pretty(notif_xml_pretty)
 
 
+    # convert raw object to an InstanceValue, an ObjectValue, not a RootNode as per DataModel.from_raw()
+    notif_inst_val = data_model.schema.from_raw(notif_obj) # , force_namespace=True)  #)
 
+    assert(str(notif_inst_val) == str(notif_obj))
 
-# Commenting out since none work
-#
-#    #########
-#    # NOTIF #  (most common?)
-#    #########
-#
-#    notif_obj = {
-#        "testb:noA" : {
-#            "leafO" : True
-#        }
-#    }
-#    notif_xml_pretty = """
-#        <noa xmlns="http://example.com/testb">
-#            <leafO>true</leafO>
-#        </noa>
-#    """
-#    notif_xml_stripped = strip_pretty(notif_xml_pretty)
-#
-#
-#    # convert raw object to an InstanceValue, an ObjectValue, not a RootNode as per DataModel.from_raw()
-#    notif_inst_val = sn_notif.from_raw(notif_obj, allow_nodata=True)
-#    assert(str(notif_inst_val) == str(notif_obj))
-#
-#
 #    ###################
 #    # JSON - RESTCONF #  (per RFC 8040)
 #    ###################
@@ -1159,7 +1109,7 @@ def test_top_level_nodes(data_model):
 #    #print("root = " + str(root))
 #
 #    sn = data_model.get_schema_node("/")
-#    instval = sn.from_raw(rv, allow_nodata=True)
+#    instval = sn.from_raw(rv)
 #    #print("instval = " + str(instval))
 #
 #    inst = RootNode(instval, sn, data_model.schema_data, instval.timestamp)

--- a/yangson/instance.py
+++ b/yangson/instance.py
@@ -552,7 +552,13 @@ class InstanceNode:
             # Array outside an Object doesn't make sense
             raise NotImplementedError
         else:
-            element.text = self.schema_node.type.to_xml(self.value)
+            sn = self.schema_node
+            if isinstance(sn.type, IdentityrefType) and sn.ns != self.value[1]:
+                module = self.schema_data.modules_by_name.get(self.value[1])
+                if not module:
+                    raise MissingModuleNamespace(sn.ns)
+                element.attrib['xmlns:'+self.value[1]] = module.xml_namespace
+            element.text = sn.type.to_xml(self.value)
 
         if elem is not None:
             return element
@@ -1336,3 +1342,5 @@ from .schemanode import (       # NOQA
             ChoiceNode, DataNode, InputNode,
             InternalNode, LeafNode, LeafListNode, ListNode, NotificationNode,
             OutputNode, RpcActionNode, SequenceNode, TerminalNode)
+from .datatype import (
+            IdentityrefType)

--- a/yangson/schemanode.py
+++ b/yangson/schemanode.py
@@ -454,7 +454,7 @@ class InternalNode(SchemaNode):
                 res.extend(child.data_children())
         return res
 
-    def from_raw(self: "InternalNode", rval: RawObject, jptr: JSONPointer = "", allow_nodata: bool = False) -> ObjectValue:
+    def from_raw(self: "InternalNode", rval: RawObject, jptr: JSONPointer = "") -> ObjectValue:
         """Override the superclass method."""
         if not isinstance(rval, dict):
             raise RawTypeError(jptr, "object")
@@ -469,33 +469,33 @@ class InternalNode(SchemaNode):
                 res[qn] = self._process_metadata(rval[qn], jptr)
             else:
                 cn = self._iname2qname(qn)
-                if allow_nodata:
+                ch = self.get_data_child(*cn)
+                if jptr == "" and ch is None:
                     ch = self.get_child(*cn)
-                else:
-                    ch = self.get_data_child(*cn)
+                    if not isinstance(ch, SchemaTreeNode):
+                        ch = None
                 npath = jptr + "/" + qn
                 if ch is None:
                     raise RawMemberError(npath)
-                if (allow_nodata or isinstance(self, SchemaTreeNode) or
-                    self.ns != ch.ns):
+                if jptr == "" or self.ns != ch.ns:
                     iname = '{1}:{0}'.format(*ch.qual_name)
                 else:
                     iname = ch.name
                 res[iname] = ch.from_raw(rval[qn], npath)
         return res
 
-    def from_xml(self: "InternalNode", rval: ET.Element, jptr: JSONPointer = "", isroot: bool = False, allow_nodata: bool = False) -> ObjectValue:
+    def from_xml(self: "InternalNode", rval: ET.Element, jptr: JSONPointer = "") -> ObjectValue:
         res = ObjectValue()
-        if isroot:
-            self._process_xmlobj_child(res, None, rval, jptr, allow_nodata)
+        if isinstance(self, RpcActionNode) and jptr == "":
+            self._process_xmlobj_child(res, None, rval, jptr)
         else:
             for xmlchild in rval:
-                self._process_xmlobj_child(res, rval, xmlchild, jptr, allow_nodata)
+                self._process_xmlobj_child(res, rval, xmlchild, jptr)
         return res
 
     def _process_xmlobj_child(
             self: "InternalNode", res: ObjectValue, rval: ET.Element,
-            xmlchild: ET.Element, jptr: JSONPointer, allow_nodata):
+            xmlchild: ET.Element, jptr: JSONPointer):
         if xmlchild.tag[0] == '{':
             xmlns, name = xmlchild.tag[1:].split('}')
             nsmap = self.schema_root().schema_data.modules_by_ns
@@ -509,10 +509,11 @@ class InternalNode(SchemaNode):
             fqn = ns + ':' + name
         qn = fqn if ns != self.ns else name
 
-        if allow_nodata:
+        ch = self.get_data_child(name, ns)
+        if jptr == "" and ch is None:
             ch = self.get_child(name, ns)
-        else:
-            ch = self.get_data_child(name, ns)
+            if not isinstance(ch, SchemaTreeNode):
+                ch = None
         npath = jptr + "/" + qn
         if ch is None:
             raise RawMemberError(npath)


### PR DESCRIPTION
Hi Lada,

- This PR closes both #78 and #87.
- You should be happy because it removes all those "isroot" and "allow_nodata" parameters.
- At this point, I'd say the XML-support is "good" (not "great" because there are still #77 and #80)
- Both Henning and I have tested against our servers.
- I have merged your recent `master` as well, so diffs should be small (and no Python 3.6 breaks)

Please merge and publish update.

Thanks,
Kent
