### PR TITLE
adds Instance.instance_id()

### DIFF
--- a/yang-modules/test/test@2016-04-26.yang
+++ b/yang-modules/test/test@2016-04-26.yang
@@ -215,4 +215,60 @@ module test {
       }
     }
   }
+
+  container cont-cf {
+    description
+      "config false to test the 'no list key' scenarios";
+    config false;
+    grouping g {
+      leaf-list leaf-list {
+        type int8;
+      }
+      list list-nk { // no key
+        leaf v {
+          type int8;
+        }
+      }
+      list list-sk { // single key
+        key 'k';
+        leaf k {
+          type string;
+        }
+        leaf v {
+          type int8;
+        }
+      }
+      list list-dk { // double key
+        key 'k1 k2';
+        leaf k1 {
+          type string;
+        }
+        leaf k2 {
+          type string;
+        }
+        leaf v {
+          type int8;
+        }
+      }
+    } // end grouping g
+
+    uses g {
+      augment 'list-nk' {
+        container l2 {
+          uses g;
+        }
+      }
+      augment 'list-sk' {
+        container l2 {
+          uses g;
+        }
+      }
+      augment 'list-dk' {
+        container l2 {
+          uses g;
+        }
+      }
+    } // end uses g
+  } // end cont-cf
+
 }

--- a/yangson/instance.py
+++ b/yangson/instance.py
@@ -201,6 +201,35 @@ class InstanceNode:
             inst = inst.parinst
         return "/" + "/".join(str(c) for c in res)
 
+
+    def instance_id(self: "InstanceNode") -> str:
+        '''this returns the JSON-form described in Section 6.11 of RFC 7951'''
+        res = []
+        inst = self
+        while inst.parinst:
+            if isinstance(inst, ArrayEntry):
+                seg = inst.name
+                if isinstance(inst.schema_node, ListNode):
+                    if len(inst.schema_node.keys) == 0:
+                        seg += '[' + str(inst.index+1) + ']'
+                    else:
+                        for k in inst.schema_node.keys:
+                            val = str(inst.value[k[0]])
+                            if type(inst.schema_node.get_child(*k).type) == BooleanType:
+                                val = val.lower()
+                            seg += '[' + k[0] + "='" + val + "']"
+                else: # LeaflistNode
+                    val = str(inst.value)
+                    if type(inst.schema_node.type) == BooleanType:
+                        val = val.lower()
+                    seg += "[.='" + val + "']"
+                res.insert(0, seg)
+                inst = inst.parinst
+            else:
+                res.insert(0, inst.name)
+            inst = inst.parinst
+        return "/" + "/".join(str(c) for c in res)
+
     def __getitem__(self: "InstanceNode", key: InstanceKey) -> "InstanceNode":
         """Return member or entry with the given key.
 
@@ -1343,4 +1372,4 @@ from .schemanode import (       # NOQA
             InternalNode, LeafNode, LeafListNode, ListNode, NotificationNode,
             OutputNode, RpcActionNode, SequenceNode, TerminalNode)
 from .datatype import (
-            IdentityrefType)
+            IdentityrefType, BooleanType)


### PR DESCRIPTION
This PR adds `Instance.instance_id()`, which returns an [RFC 7951 instance-identifier](https://tools.ietf.org/html/rfc7951#section-6.11).  _Notably, it is **NOT** an RFC 7950 instance-identifier_, but that seems okay since Yangson is skewed towards JSON.

Additionally:

  1. `yang-models/test/test@2016-04-26.yang` was updated to include a new top-level "test:cont-cf" container that contains recursive instances of:
         - lists with no keys
         - lists with single keys
         - lists with double keys

   2. `tests/test_model.py` was updated to include a new `test_instance_id()` test that traverses the entire data tree (including all previously-existing nodes) and, for each node (except the root node), the new Instance.instance_id() is roundtripped like this:
         - iid = inst.instance_id()
         - irt = data_model.parse_instance_id(iid)
         - inst2 = inst.top().goto(irt)
         - assert(str(inst) == str(inst2))
 
Note the 'FIXME' in tests/test_model.py is used to skip over the root node as otherwise `parse_instance_id()` throws an  `UnexpectedInput: /: expected YANG identifier` exception...Don't root nodes have an instance-identifiers too?