### PR TITLE
mkylib.py improvements

### DIFF
--- a/tools/python/mkylib.py
+++ b/tools/python/mkylib.py
@@ -31,8 +31,7 @@ def module_entry(yfile):
         yfile (file): File containing a YANG module or submodule.
     """
     ytxt = yfile.read()
-    mp = ModuleParser(ytxt)
-    mst = mp.statement()
+    mst = ModuleParser(ytxt).parse()
     submod = mst.keyword == "submodule"
     import_only = True
     rev = ""
@@ -98,6 +97,7 @@ def main():
             men["submodule"] = sarr
         men["conformance-type"] = "import" if imp_only else "implement"
         marr.append(men)
+    marr = sorted(marr, key=lambda item: item['name'])
     res = {
         "ietf-yang-library:modules-state": {
             "module-set-id": "",


### PR DESCRIPTION
As it is script for internal purposes, its is still very valuable, so I'd like to add some good points:
1. Sorting of all module records. This improves comparison between different yang-library.json versions, diffs just easier to read.
2. Solve parsing problem. Prev implementation would fail to parse YANG module if it starts with comment or whitespace. This eliminates problem.

Any questions or edits are welcomed.