### PR TITLE
Optimize NodeSet bind method

### DIFF
--- a/yangson/nodeset.py
+++ b/yangson/nodeset.py
@@ -45,10 +45,8 @@ class NodeSet(list):
         return self.__class__(self + [n for n in ns if n.path not in paths])
 
     def bind(self: "NodeSet", trans: NodeExpr) -> "NodeSet":
-        res = self.__class__([])
-        for n in self:
-            res = res.union(trans(n))
-        return res
+        return self.__class__({m.path: m for n in self
+                                for m in trans(n)}.values())
 
     def __float__(self: "NodeSet") -> float:
         return float(self[0].value)


### PR DESCRIPTION
Make computation more efficient by generating the NodeSet based on a
single dict comprehension instead of repeatedly calling the union
method.