### PR TITLE
Fix errors in InstanceNode.to_xml()

### DIFF
--- a/yangson/instance.py
+++ b/yangson/instance.py
@@ -552,12 +552,13 @@ class InstanceNode:
             raise NotImplementedError
         else:
             sn = self.schema_node
-            if isinstance(sn.type, IdentityrefType) and sn.ns != self.value[1]:
-                module = self.schema_data.modules_by_name.get(self.value[1])
-                if not module:
-                    raise MissingModuleNamespace(sn.ns)
-                element.attrib['xmlns:'+self.value[1]] = module.xml_namespace
-            element.text = sn.type.to_xml(self.value)
+            if isinstance(sn, TerminalNode):
+                if isinstance(sn.type, IdentityrefType):
+                    module = self.schema_data.modules_by_name.get(self.value[1])
+                    if not module:
+                        raise MissingModuleNamespace(sn.ns)
+                    element.attrib['xmlns:'+self.value[1]] = module.xml_namespace
+                element.text = sn.type.to_xml(self.value)
 
         if elem is not None:
             return element


### PR DESCRIPTION
Previous logic assumes that `sn.type` exists before testing
if `sn` is a TerminalNode.  This PR wraps the existing logic
with an `if isinstance(sn, TerminalNode)` condition.

Also note that the `and sn.ns != self.value[1]` condition has
been removed.  Otherwise converted identityrefs produce
an invalid XML document and, in any case, it doesn't hurt 
to redundantly specify an `xmlns`.  FWIW, I was using the 
Jukebox example. from RFC 8040.  This is the identityref 
that wouldn't convert otherwise:

    "genre" : "example-jukebox:alternative"

K.