### PR TITLE
Test cases for new InstanceNode.merge() method

### DIFF
--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1195,3 +1195,132 @@ def test_instance_ids(data_model, data):
 
     # run recursive traversal test
     traverse(inst)
+
+
+
+
+def test_merge_no_op(data_model, data):
+
+    # raw -> inst
+    inst = data_model.from_raw(data)
+    assert inst.validate(ctype=ContentType.all) is None
+
+    # merge same raw into inst (nothing should change)
+    new_inst = inst.merge(data, True)
+    assert new_inst.validate(ctype=ContentType.all) is None
+    new_rv = new_inst.raw_value()
+    data['test:contT']['decimal64'] = '4.5' # the canonical value returned by Yangson
+    assert(new_rv == data)
+
+
+
+def test_merge_simple(data_model, data):
+
+    # raw -> inst
+    inst = data_model.from_raw(data)
+    assert inst.validate(ctype=ContentType.all) is None
+
+    # prep data to merge
+    incoming = {
+      "test:llistB": [
+        "127.0.0.1",
+        "10.20.30.40"
+      ],
+      "test:leafX": 55555,
+      "test:contA": {
+        "leafB": 9,
+        "listA": [
+          {
+            "leafE": "C0FFEE",
+            "leafF": True,
+            "contD": {
+              "leafG": "foo1-bar",
+              "contE": {
+                "leafJ": [None],
+                "leafP": 11
+              }
+            }
+          },
+          {
+            "leafE": "ABBA",
+            "leafW": 9,
+            "leafF": False
+          },
+          {
+            "leafE": "deadbea7",
+            "leafF": False,
+            "contD": {
+              "leafG": "foo1-bar2"
+            }
+          }
+        ],
+        "testb:leafR": "C0FFEE",
+        "testb:leafT": "test:CC-BY",
+        "testb:leafV": 99,
+        "anydA": { "foo:bar": [ 2, 3, 4 ] },
+        "testb:leafN": "hi!"
+      },
+      "test:contT": {
+        "bits": "dos",
+        "decimal64": "4.5",
+        "enumeration": "Clubs"
+      }
+    }
+    valid = data_model.from_raw(incoming)
+    assert valid.validate(ctype=ContentType.all) is None
+
+    expected = {
+      "test:llistB": [
+        "127.0.0.1",
+        "10.20.30.40"
+      ],
+      "test:leafX": 55555,
+      "test:contA": {
+        "leafB": 9,
+        "listA": [
+          {
+            "leafE": "C0FFEE",
+            "leafF": True,
+            "contD": {
+              "leafG": "foo1-bar",
+              "contE": {
+                "leafJ": [None],
+                "leafP": 11
+              }
+            }
+          },
+          {
+            "leafE": "ABBA",
+            "leafW": 9,
+            "leafF": False
+          },
+          {
+            "leafE": "deadbea7",
+            "leafF": False,
+            "contD": {
+              "leafG": "foo1-bar2"
+            }
+          }
+        ],
+        "testb:leafR": "C0FFEE",
+        "testb:leafT": "test:CC-BY",
+        "testb:leafV": 99,
+        "anydA": { "foo:bar": [ 2, 3, 4 ] },
+        "testb:leafN": "hi!"
+      },
+      "test:contT": {
+        "bits": "dos",
+        "decimal64": "4.5",
+        "enumeration": "Clubs"
+      }
+    }
+
+
+    # merge and test
+    new = inst.merge(incoming, True)
+    assert inst.validate(ctype=ContentType.all) is None
+    new_rv = new.raw_value()
+    #data['test:contT']['decimal64'] = '4.5' # the canonical value returned by Yangson
+    assert(new_rv == expected)
+
+

--- a/yang-modules/test/test.yang
+++ b/yang-modules/test/test.yang
@@ -88,7 +88,7 @@ module test {
         uses d:grB {
           augment "contE" {
             leaf leafP {
-	      when "../leafU != 'false'";
+              when "../leafU != 'false'";
               type uint8;
             }
           }
@@ -102,7 +102,7 @@ module test {
         must ".";
       }
       leaf leafW {
-	type d:typE;
+        type d:typE;
       }
       container contD {
         leaf leafG {
@@ -194,7 +194,7 @@ module test {
         enum Diamonds {
           if-feature "feB";
         }
-	enum Clubs;
+        enum Clubs;
       }
     }
     leaf bits {
@@ -205,7 +205,7 @@ module test {
         bit tres {
           if-feature "feB";
         }
-	bit cuatro;
+        bit cuatro;
       }
       default "cuatro";
     }


### PR DESCRIPTION
Hi Lada,

There are two test cases:
  - no-op: merges self into self, asserts no diff.
  - simple: merges a tweaked-self into self, asserts expected diff.

Additionally, I integrated into my project and it seems to be working okay...albeit, the project test-cases just uses the Jukebox data-model and data-set from RFC 8040.  :laugh:

It is still my opinion that:
  - leaf-lists should be merged
  - ordered-by user [leaf-]lists should be collated
  - bits should be merged

That is, ConfD got it right, libyang got it half-right, YumaPro and now Yangson got it wrong.

If you're willing to update to match ConfD's approach, I'm happy to provide another PR.  Otherwise, I concede that there is no definition, it's your project, and it doesn't seem to matter in practice (Andy said)...

Thanks for helping to make this update happen!

Best regards,
Kent