### PR TITLE
Fix typing.re DeprecationWarning

### DIFF
--- a/yangson/parser.py
+++ b/yangson/parser.py
@@ -23,7 +23,7 @@ This module implements the following class:
 """
 import re
 from typing import Callable, List, Dict, Optional, Tuple
-from typing.re import Pattern
+from typing import Pattern
 from .exceptions import EndOfInput, UnexpectedInput
 from .typealiases import YangIdentifier
 


### PR DESCRIPTION
On Python 3.11:
```
yangson/parser.py:26: DeprecationWarning: typing.re is deprecated, import directly from typing instead. typing.re will be removed in Python 3.12.
    from typing.re import Pattern
```

After this update, the `pytest` are fine (on 3.11)

According to https://bugs.python.org/issue38291, Python 3.6 should work.

I tried to confirm on latest 3.6.15, but `python setup.py install` throws:

```
Traceback (most recent call last):
  File "setup.py", line 59, in <module>
    """
  File "/Users/kent/.pyenv/versions/3.6.15/lib/python3.6/site-packages/setuptools/__init__.py", line 143, in setup
    return distutils.core.setup(**attrs)
  File "/Users/kent/.pyenv/versions/3.6.15/lib/python3.6/distutils/core.py", line 108, in setup
    _setup_distribution = dist = klass(attrs)
  File "/Users/kent/.pyenv/versions/3.6.15/lib/python3.6/site-packages/setuptools/dist.py", line 442, in __init__
    k: v for k, v in attrs.items()
  File "/Users/kent/.pyenv/versions/3.6.15/lib/python3.6/distutils/dist.py", line 281, in __init__
    self.finalize_options()
  File "/Users/kent/.pyenv/versions/3.6.15/lib/python3.6/site-packages/setuptools/dist.py", line 601, in finalize_options
    ep.load()(self, ep.name, value)
  File "/Users/kent/.pyenv/versions/3.6.15/lib/python3.6/site-packages/pkg_resources/__init__.py", line 2346, in load
    return self.resolve()
  File "/Users/kent/.pyenv/versions/3.6.15/lib/python3.6/site-packages/pkg_resources/__init__.py", line 2352, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/Users/kent/Code/GitHub/kwatsen/yangson/.eggs/setuptools_scm-7.1.0-py3.6.egg/setuptools_scm/__init__.py", line 5
    from __future__ import annotations
    ^
SyntaxError: future feature annotations is not defined
```

Same for `python setup.py develop`.